### PR TITLE
feat: Integrate Tanstack React Query with a global provider, error boundary, and devtools.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { QueryProvider } from "@/providers/query-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,9 +28,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <div suppressHydrationWarning>
-          {children}
-        </div>
+        <QueryProvider>
+          <div suppressHydrationWarning>
+            {children}
+          </div>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -36,16 +36,18 @@ const buttonVariants = cva(
   }
 )
 
+type ButtonProps = React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }
+
 function Button({
   className,
   variant = "default",
   size = "default",
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+}: ButtonProps) {
   const Comp = asChild ? Slot : "button"
 
   return (
@@ -59,4 +61,5 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants, type ButtonProps }
+

--- a/components/ui/resizable.tsx
+++ b/components/ui/resizable.tsx
@@ -2,16 +2,20 @@
 
 import * as React from "react"
 import { GripVerticalIcon } from "lucide-react"
-import * as ResizablePrimitive from "react-resizable-panels"
+import {
+  Group,
+  Panel,
+  Separator,
+} from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"
 
 function ResizablePanelGroup({
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: React.ComponentProps<typeof Group>) {
   return (
-    <ResizablePrimitive.PanelGroup
+    <Group
       data-slot="resizable-panel-group"
       className={cn(
         "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
@@ -24,19 +28,19 @@ function ResizablePanelGroup({
 
 function ResizablePanel({
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}: React.ComponentProps<typeof Panel>) {
+  return <Panel data-slot="resizable-panel" {...props} />
 }
 
 function ResizableHandle({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof Separator> & {
   withHandle?: boolean
 }) {
   return (
-    <ResizablePrimitive.PanelResizeHandle
+    <Separator
       data-slot="resizable-handle"
       className={cn(
         "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
@@ -49,8 +53,10 @@ function ResizableHandle({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </Separator>
   )
 }
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle }
+
+

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-query": "^5.90.20",
+    "@tanstack/react-query-devtools": "^5.91.2",
     "better-auth": "^1.4.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/providers/query-error-boundary.tsx
+++ b/providers/query-error-boundary.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryState {
+    hasError: boolean;
+    error: Error | null;
+}
+
+interface ErrorBoundaryProps {
+    children: ReactNode;
+    onReset?: () => void;
+}
+
+class ErrorBoundaryFallback extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    constructor(props: ErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false, error: null };
+    }
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+        // Log to error reporting service in production
+        if (process.env.NODE_ENV === 'production') {
+            console.error('Query Error:', error, errorInfo);
+        }
+    }
+
+    handleReset = (): void => {
+        this.setState({ hasError: false, error: null });
+        this.props.onReset?.();
+    };
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <div className="flex min-h-[200px] flex-col items-center justify-center gap-4 rounded-lg border border-destructive/50 bg-destructive/10 p-6">
+                    <div className="text-center">
+                        <h2 className="text-lg font-semibold text-destructive">
+                            Something went wrong
+                        </h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            {this.state.error?.message || 'An unexpected error occurred while fetching data.'}
+                        </p>
+                    </div>
+                    <button
+                        onClick={this.handleReset}
+                        className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+                    >
+                        Try again
+                    </button>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+interface QueryErrorBoundaryProps {
+    children: ReactNode;
+}
+
+export function QueryErrorBoundary({ children }: QueryErrorBoundaryProps) {
+    return (
+        <QueryErrorResetBoundary>
+            {({ reset }) => (
+                <ErrorBoundaryFallback onReset={reset}>
+                    {children}
+                </ErrorBoundaryFallback>
+            )}
+        </QueryErrorResetBoundary>
+    );
+}

--- a/providers/query-provider.tsx
+++ b/providers/query-provider.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useState, type ReactNode } from 'react';
+import { QueryErrorBoundary } from './query-error-boundary';
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000, // 60 seconds
+        gcTime: 5 * 60 * 1000, // 5 minutes (formerly cacheTime)
+        retry: 3,
+        retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: 3,
+        retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined;
+
+function getQueryClient(): QueryClient {
+  if (typeof window === 'undefined') {
+    // Server: always create a new QueryClient
+    return makeQueryClient();
+  }
+  // Browser: reuse existing client or create new one
+  if (!browserQueryClient) {
+    browserQueryClient = makeQueryClient();
+  }
+  return browserQueryClient;
+}
+
+interface QueryProviderProps {
+  children: ReactNode;
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  const [queryClient] = useState(getQueryClient);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <QueryErrorBoundary>
+        {children}
+      </QueryErrorBoundary>
+      {process.env.NODE_ENV === 'development' && (
+        <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
+      )}
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
This pull request introduces React Query for state management, adds error boundaries for query errors, and refactors some UI components for improved type safety and maintainability. The most significant changes are the integration of React Query and the addition of a global query provider, along with improvements to the resizable UI components.

**React Query Integration and Error Handling:**

- Added `@tanstack/react-query` and `@tanstack/react-query-devtools` dependencies to `package.json` for data fetching and caching.
- Created a global `QueryProvider` (`providers/query-provider.tsx`) that wraps the app, configures the query client, and provides error boundaries and devtools in development.
- Added a `QueryErrorBoundary` component (`providers/query-error-boundary.tsx`) to gracefully handle and display errors from React Query operations.
- Updated `app/layout.tsx` to wrap the application in the `QueryProvider`, ensuring all components have access to React Query context. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR4) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR31-R35)

**UI Component Improvements:**

- Refactored the resizable panel components in `components/ui/resizable.tsx` to use named imports (`Group`, `Panel`, `Separator`) from `react-resizable-panels` instead of the namespace import, improving clarity and maintainability. [[1]](diffhunk://#diff-42b05bb3e90e38d2e3aad678ba68e4126c980cfef57eb7a5ea99e9c4950040c0L5-R18) [[2]](diffhunk://#diff-42b05bb3e90e38d2e3aad678ba68e4126c980cfef57eb7a5ea99e9c4950040c0L27-R43) [[3]](diffhunk://#diff-42b05bb3e90e38d2e3aad678ba68e4126c980cfef57eb7a5ea99e9c4950040c0L52-R62)
- Extracted and exported the `ButtonProps` type from `components/ui/button.tsx` for better type reuse and code clarity. [[1]](diffhunk://#diff-2795b661f0806f90ae4821c33bdc2c7615156b270ec45bde4769727f4b6bc748R39-R50) [[2]](diffhunk://#diff-2795b661f0806f90ae4821c33bdc2c7615156b270ec45bde4769727f4b6bc748L62-R65)

closes #21 