### PR TITLE
feat: migrate bounty mutation hooks to GraphQL

### DIFF
--- a/hooks/Use-bounty-detail.ts
+++ b/hooks/Use-bounty-detail.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { bountiesApi, type Bounty } from "@/lib/api";
-import { bountyKeys } from "./use-bounties";
+import { bountyKeys } from "@/lib/query/query-keys";
 
 export function useBountyDetail(id: string) {
   return useQuery<Bounty>({

--- a/hooks/use-bounties.ts
+++ b/hooks/use-bounties.ts
@@ -1,17 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
-import { bountiesApi, type Bounty, type BountyListParams, type PaginatedResponse } from '@/lib/api';
-
-export const bountyKeys = {
-    all: ['bounties'] as const,
-    lists: () => [...bountyKeys.all, 'list'] as const,
-    list: (params?: BountyListParams) => [...bountyKeys.lists(), params] as const,
-    details: () => [...bountyKeys.all, 'detail'] as const,
-    detail: (id: string) => [...bountyKeys.details(), id] as const,
-};
+import { useQuery } from "@tanstack/react-query";
+import {
+  bountiesApi,
+  type Bounty,
+  type BountyListParams,
+  type PaginatedResponse,
+} from "@/lib/api";
+import { bountyKeys } from "@/lib/query/query-keys";
 
 export function useBounties(params?: BountyListParams) {
-    return useQuery<PaginatedResponse<Bounty>>({
-        queryKey: bountyKeys.list(params),
-        queryFn: () => bountiesApi.list(params),
-    });
+  return useQuery<PaginatedResponse<Bounty>>({
+    queryKey: bountyKeys.list(params),
+    queryFn: () => bountiesApi.list(params),
+  });
 }

--- a/hooks/use-bounty-mutations.ts
+++ b/hooks/use-bounty-mutations.ts
@@ -203,7 +203,9 @@ export function useDeleteBounty() {
       });
     },
     onSettled: (_data, _err, id) => {
-      queryClient.removeQueries({ queryKey: bountyKeys.detail(id) });
+      if (!_err) {
+        queryClient.removeQueries({ queryKey: bountyKeys.detail(id) });
+      }
       queryClient.invalidateQueries({ queryKey: bountyKeys.lists() });
     },
   });

--- a/hooks/use-bounty.ts
+++ b/hooks/use-bounty.ts
@@ -1,15 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
-import { bountiesApi, type Bounty } from '@/lib/api';
-import { bountyKeys } from './use-bounties';
+import { useQuery } from "@tanstack/react-query";
+import { bountiesApi, type Bounty } from "@/lib/api";
+import { bountyKeys } from "@/lib/query/query-keys";
 
 interface UseBountyOptions {
-    enabled?: boolean;
+  enabled?: boolean;
 }
 
 export function useBounty(id: string, options?: UseBountyOptions) {
-    return useQuery<Bounty>({
-        queryKey: bountyKeys.detail(id),
-        queryFn: () => bountiesApi.getById(id),
-        enabled: options?.enabled ?? !!id,
-    });
+  return useQuery<Bounty>({
+    queryKey: bountyKeys.detail(id),
+    queryFn: () => bountiesApi.getById(id),
+    enabled: options?.enabled ?? !!id,
+  });
 }

--- a/hooks/use-infinite-bounties.ts
+++ b/hooks/use-infinite-bounties.ts
@@ -1,29 +1,38 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { bountiesApi, type Bounty, type BountyListParams, type PaginatedResponse } from '@/lib/api';
-import { bountyKeys } from './use-bounties';
+import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  bountiesApi,
+  type Bounty,
+  type BountyListParams,
+  type PaginatedResponse,
+} from "@/lib/api";
+import { bountyKeys } from "@/lib/query/query-keys";
 
 const DEFAULT_LIMIT = 20;
 
-export function useInfiniteBounties(params?: Omit<BountyListParams, 'page'>) {
-    return useInfiniteQuery<PaginatedResponse<Bounty>>({
-        queryKey: [...bountyKeys.lists(), 'infinite', params] as const,
-        queryFn: ({ pageParam }) =>
-            bountiesApi.list({ ...params, page: pageParam as number, limit: params?.limit ?? DEFAULT_LIMIT }),
-        initialPageParam: 1,
-        getNextPageParam: (lastPage) => {
-            const { page, totalPages } = lastPage.pagination;
-            return page < totalPages ? page + 1 : undefined;
-        },
-        getPreviousPageParam: (firstPage) => {
-            const { page } = firstPage.pagination;
-            return page > 1 ? page - 1 : undefined;
-        },
-    });
+export function useInfiniteBounties(params?: Omit<BountyListParams, "page">) {
+  return useInfiniteQuery<PaginatedResponse<Bounty>>({
+    queryKey: bountyKeys.infinite(params),
+    queryFn: ({ pageParam }) =>
+      bountiesApi.list({
+        ...params,
+        page: pageParam as number,
+        limit: params?.limit ?? DEFAULT_LIMIT,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      const { page, totalPages } = lastPage.pagination;
+      return page < totalPages ? page + 1 : undefined;
+    },
+    getPreviousPageParam: (firstPage) => {
+      const { page } = firstPage.pagination;
+      return page > 1 ? page - 1 : undefined;
+    },
+  });
 }
 
 // Helper to flatten infinite query pages
 export function flattenBountyPages(
-    pages: PaginatedResponse<Bounty>[] | undefined
+  pages: PaginatedResponse<Bounty>[] | undefined,
 ): Bounty[] {
-    return pages?.flatMap((page) => page.data) ?? [];
+  return pages?.flatMap((page) => page.data) ?? [];
 }

--- a/lib/query/sync/handlers.ts
+++ b/lib/query/sync/handlers.ts
@@ -1,9 +1,9 @@
-import { QueryClient } from '@tanstack/react-query';
-import { Bounty, PaginatedResponse } from '@/lib/api';
-import { bountyKeys } from '@/hooks/use-bounties';
+import { QueryClient } from "@tanstack/react-query";
+import { Bounty, PaginatedResponse } from "@/lib/api";
+import { bountyKeys } from "@/lib/query/query-keys";
 
 export function handleBountyCreated(queryClient: QueryClient, bounty: Bounty) {
-  console.log('[Sync] Handling bounty.created:', bounty.id);
+  console.log("[Sync] Handling bounty.created:", bounty.id);
 
   // Update lists
   queryClient.setQueriesData<PaginatedResponse<Bounty>>(
@@ -18,7 +18,7 @@ export function handleBountyCreated(queryClient: QueryClient, bounty: Bounty) {
           total: oldData.pagination.total + 1,
         },
       };
-    }
+    },
   );
 
   // Set detail cache
@@ -26,7 +26,7 @@ export function handleBountyCreated(queryClient: QueryClient, bounty: Bounty) {
 }
 
 export function handleBountyUpdated(queryClient: QueryClient, bounty: Bounty) {
-  console.log('[Sync] Handling bounty.updated:', bounty.id);
+  console.log("[Sync] Handling bounty.updated:", bounty.id);
 
   // Update lists
   queryClient.setQueriesData<PaginatedResponse<Bounty>>(
@@ -37,15 +37,18 @@ export function handleBountyUpdated(queryClient: QueryClient, bounty: Bounty) {
         ...oldData,
         data: oldData.data.map((b) => (b.id === bounty.id ? bounty : b)),
       };
-    }
+    },
   );
 
   // Update detail cache
   queryClient.setQueryData(bountyKeys.detail(bounty.id), bounty);
 }
 
-export function handleBountyDeleted(queryClient: QueryClient, bountyId: string) {
-  console.log('[Sync] Handling bounty.deleted:', bountyId);
+export function handleBountyDeleted(
+  queryClient: QueryClient,
+  bountyId: string,
+) {
+  console.log("[Sync] Handling bounty.deleted:", bountyId);
 
   // Update lists
   queryClient.setQueriesData<PaginatedResponse<Bounty>>(
@@ -60,7 +63,7 @@ export function handleBountyDeleted(queryClient: QueryClient, bountyId: string) 
           total: Math.max(0, oldData.pagination.total - 1),
         },
       };
-    }
+    },
   );
 
   // Invalidate or remove detail cache


### PR DESCRIPTION
## Summary
- migrate `hooks/use-bounty-mutations.ts` write paths from REST `bountiesApi` calls to GraphQL mutation calls via `fetcher`
- keep optimistic cache behavior for update/delete and preserve rollback/invalidation flow
- implement `useClaimBounty` with the requested workaround by calling `updateBounty` with `status: "IN_PROGRESS"`
- switch mutation cache invalidation/cancel logic to shared `bountyKeys` from `@/lib/query/query-keys`

## Validation
- `npm run lint -- hooks/use-bounty-mutations.ts`
- pre-push `next build` (via hook) passed

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster, more responsive bounty actions with optimistic updates for create, update, delete, and claim—users see immediate feedback.
  * Better consistency between bounty lists and detail views with automatic refreshes after operations.
  * Safer error handling: changes are rolled back automatically if an operation fails.
* **Chores**
  * Public hooks and interfaces remain unchanged for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->