### PR TITLE
feat: replace hand-written bountyKeys with codegen-generated query keys

### DIFF
--- a/lib/query/query-keys.ts
+++ b/lib/query/query-keys.ts
@@ -21,19 +21,27 @@ export const bountyKeys = {
   lists: () => useBountiesQuery.getKey(),
   list: (params?: BountyQueryInput) =>
     useBountiesQuery.getKey({ query: params } as BountiesQueryVariables),
+
   // Infinite bounties queries - uses same base key as list since they fetch same data
   infinite: (params?: Omit<BountyQueryInput, "page">) =>
-    useBountiesQuery.getKey({ query: params } as BountiesQueryVariables),
+    [
+      ...useBountiesQuery.getKey({ query: params } as BountiesQueryVariables),
+      "infinite",
+    ] as const,
+
   // Single bounty detail - uses ["Bounty", variables]
   detail: (id: string) => useBountyQuery.getKey({ id } as BountyQueryVariables),
+
   // Active bounties - uses ["ActiveBounties"] or ["ActiveBounties", variables]
   active: (variables?: ActiveBountiesQueryVariables) =>
     useActiveBountiesQuery.getKey(variables),
+
   // Organization bounties - uses ["OrganizationBounties", variables]
   organization: (organizationId: string) =>
     useOrganizationBountiesQuery.getKey({
       organizationId,
     } as OrganizationBountiesQueryVariables),
+
   // Project bounties - uses ["ProjectBounties", variables]
   project: (projectId: string) =>
     useProjectBountiesQuery.getKey({


### PR DESCRIPTION
## Summary

Replaced hand-written `bountyKeys` with codegen-generated query keys using `exposeQueryKeys: true`, establishing a single source of truth for all bounty query keys.

---

## Changes

* Reviewed `generated.ts` key exports:

  * `useBountiesQuery.getKey()`
  * `useBountyQuery.getKey()`
  * `useActiveBountiesQuery.getKey()`
  * `useOrganizationBountiesQuery.getKey()`
  * `useProjectBountiesQuery.getKey()`

* Updated `lib/query/query-keys.ts` to delegate to generated `getKey` methods.

* Removed redundant hand-written key factories.

* Existing hooks, handlers, and mutations now automatically use generated keys via `bountyKeys`.

* Prefetch utilities already aligned — no changes needed.

---

## Acceptance Criteria

* ✅ Single source of truth for query keys (codegen)
* ✅ All cache invalidation uses generated keys
* ✅ No breaking changes
* ✅ Successful compilation

---

Closes #107

<img width="742" height="896" alt="Screenshot From 2026-02-24 13-16-19" src="https://github.com/user-attachments/assets/d162d828-a3ee-4981-a1a9-34d4bdd2dbb8" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked bounty query key generation to a codegen-driven, wrapped-key approach with stronger typing and clearer key semantics.
* **New Features**
  * Added public support for querying active bounties, organization-specific bounties, and project-specific bounties.
* **Documentation**
  * Added explicit docs describing the new key semantics and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->