### PR TITLE
fix: highlight current user on leaderboard and fix profile route

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -11,6 +11,7 @@ import {
 import { LeaderboardTimeframe } from "@/lib/graphql/generated";
 import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { authClient } from "@/lib/auth-client";
 import {
   TIMEFRAMES,
   TIERS,
@@ -45,9 +46,9 @@ export default function LeaderboardPage() {
     tags: initialTags || [],
   });
 
-  // Fake current user ID for demo purposes
-  // In a real app this would come from auth context
-  const currentUserId = "user-1";
+  // Get current user ID from auth session
+  const { data: session } = authClient.useSession();
+  const currentUserId = session?.user?.id;
 
   // Debounce filters to prevent rapid API calls/URL updates
   const [debouncedFilters, setDebouncedFilters] =
@@ -135,7 +136,7 @@ export default function LeaderboardPage() {
                 onLoadMore={() => fetchNextPage()}
                 currentUserId={currentUserId}
                 onRowClick={(entry) =>
-                  router.push(`/user/${entry.contributor.userId}`)
+                  router.push(`/profile/${entry.contributor.userId}`)
                 }
               />
             )}


### PR DESCRIPTION
## Summary

Fixes #184 - Highlight the Current User on the Leaderboard

### Changes

1. **Replaced hardcoded user ID with real auth session**
   - Before: `const currentUserId = "user-1"` (fake demo ID)
   - After: `const { data: session } = authClient.useSession(); const currentUserId = session?.user?.id;`
   - Now uses `better-auth` session to get the real authenticated user's ID

2. **Fixed broken profile route**
   - Before: `router.push('/user/${entry.contributor.userId}')` (route doesn't exist)
   - After: `router.push('/profile/${entry.contributor.userId}')` (correct route at `app/profile/[userId]`)

### Why This Matters

- Users can now see their own rank highlighted on the leaderboard
- The `UserRankSidebar` shows the actual signed-in user's rank instead of a fake user
- Clicking a leaderboard row navigates to a valid profile page instead of a 404
- Unauthenticated users still see the leaderboard with "Connect your wallet to see your rank" message

### Testing

- Auth client already exists at `lib/auth-client.ts` using `better-auth/react`
- `LeaderboardTable` already accepts `currentUserId?: string` and highlights matching rows
- `UserRankSidebar` already accepts `userId?: string` and shows empty state when undefined
- Profile route exists at `app/profile/[userId]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Leaderboard now displays your actual user information instead of a placeholder user.
  * Updated user profile navigation path for consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->