### PR TITLE
feat: Feature: Profile Settings / Edit Profile

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,15 +5,7 @@ import { QueryProvider } from "@/providers/query-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { GlobalNavbar } from "@/components/global-navbar";
-import dynamic from "next/dynamic";
-
-const SmartWalletProvider = dynamic(
-  () =>
-    import("@/components/providers/smart-wallet-provider").then(
-      (m) => m.SmartWalletProvider,
-    ),
-  { ssr: false },
-);
+import { SmartWalletProvider } from "@/components/providers/smart-wallet-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,15 @@ import { QueryProvider } from "@/providers/query-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { GlobalNavbar } from "@/components/global-navbar";
-import { SmartWalletProvider } from "@/components/providers/smart-wallet-provider";
+import dynamic from "next/dynamic";
+
+const SmartWalletProvider = dynamic(
+  () =>
+    import("@/components/providers/smart-wallet-provider").then(
+      (m) => m.SmartWalletProvider,
+    ),
+  { ssr: false },
+);
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,15 @@
+import { getCurrentUser } from "@/lib/server-auth";
+import { redirect } from "next/navigation";
+import { SettingsClient } from "./settings-client";
+
+export const metadata = { title: "Settings" };
+
+export default async function SettingsPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/auth");
+  }
+
+  return <SettingsClient user={user} />;
+}

--- a/app/settings/settings-client.tsx
+++ b/app/settings/settings-client.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ProfileTab } from "@/components/settings/profile-tab";
+import { NotificationsTab } from "@/components/settings/notifications-tab";
+import { WalletTab } from "@/components/settings/wallet-tab";
+import { DangerZoneTab } from "@/components/settings/danger-zone-tab";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import type { User } from "@/lib/server-auth";
+
+interface SettingsClientProps {
+  user: User;
+}
+
+export function SettingsClient({ user }: SettingsClientProps) {
+  const profileDefaults = {
+    name: user.name ?? "",
+    image: user.image ?? "",
+    bio: "",
+    github: "",
+    twitter: "",
+    website: "",
+  };
+
+  return (
+    <div className="container max-w-3xl mx-auto py-8 px-4">
+      <Button
+        asChild
+        variant="ghost"
+        size="sm"
+        className="mb-6 -ml-2 text-muted-foreground"
+      >
+        <Link href="/">
+          <ChevronLeft className="w-4 h-4 mr-1" />
+          Back to Home
+        </Link>
+      </Button>
+
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">Settings</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          Manage your profile, notifications, and account preferences.
+        </p>
+      </div>
+
+      <Tabs defaultValue="profile" className="w-full">
+        <TabsList className="w-full justify-start border-b rounded-none h-auto p-0 bg-transparent mb-8">
+          <TabsTrigger
+            value="profile"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-4 py-3"
+          >
+            Profile
+          </TabsTrigger>
+          <TabsTrigger
+            value="notifications"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-4 py-3"
+          >
+            Notifications
+          </TabsTrigger>
+          <TabsTrigger
+            value="wallet"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-4 py-3"
+          >
+            Wallet
+          </TabsTrigger>
+          <TabsTrigger
+            value="danger"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent px-4 py-3"
+          >
+            Danger Zone
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile">
+          <ProfileTab defaultValues={profileDefaults} />
+        </TabsContent>
+
+        <TabsContent value="notifications">
+          <NotificationsTab />
+        </TabsContent>
+
+        <TabsContent value="wallet">
+          <WalletTab />
+        </TabsContent>
+
+        <TabsContent value="danger">
+          <DangerZoneTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/app/settings/settings-client.tsx
+++ b/app/settings/settings-client.tsx
@@ -18,10 +18,10 @@ export function SettingsClient({ user }: SettingsClientProps) {
   const profileDefaults = {
     name: user.name ?? "",
     image: user.image ?? "",
-    bio: "",
-    github: "",
-    twitter: "",
-    website: "",
+    bio: user.bio ?? "",
+    github: user.github ?? "",
+    twitter: user.twitter ?? "",
+    website: user.website ?? "",
   };
 
   return (

--- a/components/settings/danger-zone-tab.tsx
+++ b/components/settings/danger-zone-tab.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, TriangleAlert } from "lucide-react";
+import { useDeleteAccountMutation } from "@/hooks/use-user-mutations";
+import { useRouter } from "next/navigation";
+
+const CONFIRM_PHRASE = "delete my account";
+
+export function DangerZoneTab() {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const router = useRouter();
+  const { mutateAsync, isPending } = useDeleteAccountMutation();
+
+  const handleDelete = async () => {
+    try {
+      await mutateAsync();
+      setOpen(false);
+      router.push("/auth");
+    } catch {
+      // error toast handled in mutation
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setConfirmText("");
+    setOpen(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 flex gap-3">
+        <TriangleAlert className="h-5 w-5 shrink-0 text-destructive mt-0.5" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-destructive">Delete account</p>
+          <p className="text-sm text-muted-foreground">
+            Permanently delete your account and all associated data. This action
+            cannot be undone.
+          </p>
+        </div>
+      </div>
+
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
+        <AlertDialogTrigger asChild>
+          <Button variant="destructive">Delete Account</Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete your account, profile, and all
+              activity. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-2 py-2">
+            <Label htmlFor="confirm-delete">
+              Type{" "}
+              <span className="font-mono font-semibold">{CONFIRM_PHRASE}</span>{" "}
+              to confirm
+            </Label>
+            <Input
+              id="confirm-delete"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={CONFIRM_PHRASE}
+              autoComplete="off"
+            />
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={confirmText !== CONFIRM_PHRASE || isPending}
+              onClick={handleDelete}
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                "Delete Account"
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/components/settings/notifications-tab.tsx
+++ b/components/settings/notifications-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -58,10 +58,10 @@ export function NotificationsTab() {
   const handleSave = async () => {
     setIsPending(true);
     try {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      toast.success("Notification preferences saved!");
-    } catch {
-      toast.error("Failed to save preferences");
+      // TODO: wire to backend notification preferences endpoint
+      toast.info(
+        "Notification preferences saved locally. Backend sync coming soon.",
+      );
     } finally {
       setIsPending(false);
     }
@@ -82,25 +82,23 @@ export function NotificationsTab() {
           </span>
 
           {eventKeys.map((key) => (
-            <>
-              <Label key={`${key}-label`} className="text-sm">
-                {eventLabels[key]}
-              </Label>
-              <div key={`${key}-inapp`} className="flex justify-center">
+            <Fragment key={key}>
+              <Label className="text-sm">{eventLabels[key]}</Label>
+              <div className="flex justify-center">
                 <Switch
                   checked={prefs[key].inApp}
                   onCheckedChange={() => toggleChannel(key, "inApp")}
                   aria-label={`${eventLabels[key]} in-app notification`}
                 />
               </div>
-              <div key={`${key}-email`} className="flex justify-center">
+              <div className="flex justify-center">
                 <Switch
                   checked={prefs[key].email}
                   onCheckedChange={() => toggleChannel(key, "email")}
                   aria-label={`${eventLabels[key]} email notification`}
                 />
               </div>
-            </>
+            </Fragment>
           ))}
         </div>
       </div>

--- a/components/settings/notifications-tab.tsx
+++ b/components/settings/notifications-tab.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Separator } from "@/components/ui/separator";
+
+interface NotificationPrefs {
+  newBounty: { inApp: boolean; email: boolean };
+  applicationUpdate: { inApp: boolean; email: boolean };
+  bountyCompleted: { inApp: boolean; email: boolean };
+  mentions: { inApp: boolean; email: boolean };
+  digestCadence: "off" | "daily" | "weekly";
+}
+
+const defaultPrefs: NotificationPrefs = {
+  newBounty: { inApp: true, email: false },
+  applicationUpdate: { inApp: true, email: true },
+  bountyCompleted: { inApp: true, email: true },
+  mentions: { inApp: true, email: false },
+  digestCadence: "off",
+};
+
+const eventLabels: Record<
+  keyof Omit<NotificationPrefs, "digestCadence">,
+  string
+> = {
+  newBounty: "New bounties posted",
+  applicationUpdate: "Application status updates",
+  bountyCompleted: "Bounty completed",
+  mentions: "Mentions and replies",
+};
+
+export function NotificationsTab() {
+  const [prefs, setPrefs] = useState<NotificationPrefs>(defaultPrefs);
+  const [isPending, setIsPending] = useState(false);
+
+  const toggleChannel = (
+    event: keyof Omit<NotificationPrefs, "digestCadence">,
+    channel: "inApp" | "email",
+  ) => {
+    setPrefs((prev) => ({
+      ...prev,
+      [event]: { ...prev[event], [channel]: !prev[event][channel] },
+    }));
+  };
+
+  const handleSave = async () => {
+    setIsPending(true);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      toast.success("Notification preferences saved!");
+    } catch {
+      toast.error("Failed to save preferences");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const eventKeys = Object.keys(eventLabels) as Array<keyof typeof eventLabels>;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-6 gap-y-4">
+          <div />
+          <span className="text-sm font-medium text-muted-foreground text-center">
+            In-app
+          </span>
+          <span className="text-sm font-medium text-muted-foreground text-center">
+            Email
+          </span>
+
+          {eventKeys.map((key) => (
+            <>
+              <Label key={`${key}-label`} className="text-sm">
+                {eventLabels[key]}
+              </Label>
+              <div key={`${key}-inapp`} className="flex justify-center">
+                <Switch
+                  checked={prefs[key].inApp}
+                  onCheckedChange={() => toggleChannel(key, "inApp")}
+                  aria-label={`${eventLabels[key]} in-app notification`}
+                />
+              </div>
+              <div key={`${key}-email`} className="flex justify-center">
+                <Switch
+                  checked={prefs[key].email}
+                  onCheckedChange={() => toggleChannel(key, "email")}
+                  aria-label={`${eventLabels[key]} email notification`}
+                />
+              </div>
+            </>
+          ))}
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <Label>Email digest</Label>
+          <p className="text-sm text-muted-foreground">
+            Receive a summary of activity at your chosen cadence.
+          </p>
+        </div>
+        <Select
+          value={prefs.digestCadence}
+          onValueChange={(value: NotificationPrefs["digestCadence"]) =>
+            setPrefs((prev) => ({ ...prev, digestCadence: value }))
+          }
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="off">Off</SelectItem>
+            <SelectItem value="daily">Daily</SelectItem>
+            <SelectItem value="weekly">Weekly</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Button onClick={handleSave} disabled={isPending}>
+        {isPending ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Saving...
+          </>
+        ) : (
+          "Save Preferences"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/components/settings/notifications-tab.tsx
+++ b/components/settings/notifications-tab.tsx
@@ -31,6 +31,18 @@ const defaultPrefs: NotificationPrefs = {
   digestCadence: "off",
 };
 
+const STORAGE_KEY = "notification-prefs";
+
+function loadPrefs(): NotificationPrefs {
+  if (typeof window === "undefined") return defaultPrefs;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? (JSON.parse(stored) as NotificationPrefs) : defaultPrefs;
+  } catch {
+    return defaultPrefs;
+  }
+}
+
 const eventLabels: Record<
   keyof Omit<NotificationPrefs, "digestCadence">,
   string
@@ -42,7 +54,7 @@ const eventLabels: Record<
 };
 
 export function NotificationsTab() {
-  const [prefs, setPrefs] = useState<NotificationPrefs>(defaultPrefs);
+  const [prefs, setPrefs] = useState<NotificationPrefs>(loadPrefs);
   const [isPending, setIsPending] = useState(false);
 
   const toggleChannel = (
@@ -58,10 +70,10 @@ export function NotificationsTab() {
   const handleSave = async () => {
     setIsPending(true);
     try {
-      // TODO: wire to backend notification preferences endpoint
-      toast.info(
-        "Notification preferences saved locally. Backend sync coming soon.",
-      );
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+      toast.success("Notification preferences saved.");
+    } catch {
+      toast.error("Failed to save notification preferences.");
     } finally {
       setIsPending(false);
     }

--- a/components/settings/profile-tab.tsx
+++ b/components/settings/profile-tab.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { useUpdateUserMutation } from "@/hooks/use-user-mutations";
+import { useQueryClient } from "@tanstack/react-query";
+import { authKeys } from "@/lib/query/query-keys";
+
+const profileSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .max(100, "Name is too long"),
+  image: z
+    .string()
+    .trim()
+    .url("Must be a valid URL")
+    .or(z.literal(""))
+    .optional(),
+  bio: z
+    .string()
+    .trim()
+    .max(500, "Bio must be 500 characters or less")
+    .optional(),
+  github: z
+    .string()
+    .trim()
+    .url("Must be a valid URL")
+    .or(z.literal(""))
+    .optional(),
+  twitter: z
+    .string()
+    .trim()
+    .url("Must be a valid URL")
+    .or(z.literal(""))
+    .optional(),
+  website: z
+    .string()
+    .trim()
+    .url("Must be a valid URL")
+    .or(z.literal(""))
+    .optional(),
+});
+
+type ProfileFormValues = z.infer<typeof profileSchema>;
+
+interface ProfileTabProps {
+  defaultValues: ProfileFormValues;
+}
+
+export function ProfileTab({ defaultValues }: ProfileTabProps) {
+  const queryClient = useQueryClient();
+  const { mutateAsync, isPending } = useUpdateUserMutation();
+
+  const form = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues,
+  });
+
+  const handleSubmit = async (values: ProfileFormValues) => {
+    const previous = queryClient.getQueryData<ProfileFormValues>(
+      authKeys.session(),
+    );
+
+    queryClient.setQueryData(authKeys.session(), (old: unknown) => {
+      if (!old || typeof old !== "object") return old;
+      const session = old as { user?: Partial<ProfileFormValues> };
+      return { ...session, user: { ...session.user, ...values } };
+    });
+
+    try {
+      await mutateAsync(values);
+    } catch {
+      queryClient.setQueryData(authKeys.session(), previous);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        <div className="space-y-4">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Display Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="Your name" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="image"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Avatar URL</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="https://example.com/avatar.png"
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="bio"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Bio</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Tell us a bit about yourself"
+                    className="resize-none"
+                    rows={4}
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="space-y-4">
+          <h3 className="text-sm font-medium">Social Links</h3>
+
+          <FormField
+            control={form.control}
+            name="github"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>GitHub</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="https://github.com/username"
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="twitter"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Twitter / X</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="https://twitter.com/username"
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="website"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Personal Website</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="https://yoursite.com"
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {form.formState.errors.root && (
+          <p className="text-sm text-destructive">
+            {form.formState.errors.root.message}
+          </p>
+        )}
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            "Save Changes"
+          )}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/components/settings/profile-tab.tsx
+++ b/components/settings/profile-tab.tsx
@@ -72,18 +72,25 @@ export function ProfileTab({ defaultValues }: ProfileTabProps) {
   });
 
   const handleSubmit = async (values: ProfileFormValues) => {
-    const previous = queryClient.getQueryData<ProfileFormValues>(
-      authKeys.session(),
-    );
+    const dirtyFields = form.formState.dirtyFields;
+    const changedValues = Object.fromEntries(
+      Object.entries(values).filter(
+        ([key]) => dirtyFields[key as keyof ProfileFormValues],
+      ),
+    ) as Partial<ProfileFormValues>;
+
+    if (Object.keys(changedValues).length === 0) return;
+
+    const previous = queryClient.getQueryData(authKeys.session());
 
     queryClient.setQueryData(authKeys.session(), (old: unknown) => {
       if (!old || typeof old !== "object") return old;
       const session = old as { user?: Partial<ProfileFormValues> };
-      return { ...session, user: { ...session.user, ...values } };
+      return { ...session, user: { ...session.user, ...changedValues } };
     });
 
     try {
-      await mutateAsync(values);
+      await mutateAsync(changedValues);
     } catch {
       queryClient.setQueryData(authKeys.session(), previous);
     }

--- a/components/settings/profile-tab.tsx
+++ b/components/settings/profile-tab.tsx
@@ -3,14 +3,8 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
+import { Form } from "@/components/ui/form";
+import { FormFieldWrapper } from "@/components/ui/form-field-wrapper";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -58,6 +52,11 @@ const profileSchema = z.object({
 
 type ProfileFormValues = z.infer<typeof profileSchema>;
 
+type SessionCache = { user?: Partial<ProfileFormValues> } & Record<
+  string,
+  unknown
+>;
+
 interface ProfileTabProps {
   defaultValues: ProfileFormValues;
 }
@@ -81,16 +80,16 @@ export function ProfileTab({ defaultValues }: ProfileTabProps) {
 
     if (Object.keys(changedValues).length === 0) return;
 
-    const previous = queryClient.getQueryData(authKeys.session());
+    const previous = queryClient.getQueryData<SessionCache>(authKeys.session());
 
-    queryClient.setQueryData(authKeys.session(), (old: unknown) => {
+    queryClient.setQueryData<SessionCache>(authKeys.session(), (old) => {
       if (!old || typeof old !== "object") return old;
-      const session = old as { user?: Partial<ProfileFormValues> };
-      return { ...session, user: { ...session.user, ...changedValues } };
+      return { ...old, user: { ...old.user, ...changedValues } };
     });
 
     try {
       await mutateAsync(changedValues);
+      form.reset(values);
     } catch {
       queryClient.setQueryData(authKeys.session(), previous);
     }
@@ -100,55 +99,38 @@ export function ProfileTab({ defaultValues }: ProfileTabProps) {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
         <div className="space-y-4">
-          <FormField
+          <FormFieldWrapper
             control={form.control}
             name="name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Display Name</FormLabel>
-                <FormControl>
-                  <Input placeholder="Your name" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
+            label="Display Name"
+            render={({ field }) => <Input placeholder="Your name" {...field} />}
           />
 
-          <FormField
+          <FormFieldWrapper
             control={form.control}
             name="image"
+            label="Avatar URL"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Avatar URL</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="https://example.com/avatar.png"
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+              <Input
+                placeholder="https://example.com/avatar.png"
+                {...field}
+                value={field.value ?? ""}
+              />
             )}
           />
 
-          <FormField
+          <FormFieldWrapper
             control={form.control}
             name="bio"
+            label="Bio"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Bio</FormLabel>
-                <FormControl>
-                  <Textarea
-                    placeholder="Tell us a bit about yourself"
-                    className="resize-none"
-                    rows={4}
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+              <Textarea
+                placeholder="Tell us a bit about yourself"
+                className="resize-none"
+                rows={4}
+                {...field}
+                value={field.value ?? ""}
+              />
             )}
           />
         </div>
@@ -156,57 +138,42 @@ export function ProfileTab({ defaultValues }: ProfileTabProps) {
         <div className="space-y-4">
           <h3 className="text-sm font-medium">Social Links</h3>
 
-          <FormField
+          <FormFieldWrapper
             control={form.control}
             name="github"
+            label="GitHub"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>GitHub</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="https://github.com/username"
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+              <Input
+                placeholder="https://github.com/username"
+                {...field}
+                value={field.value ?? ""}
+              />
             )}
           />
 
-          <FormField
+          <FormFieldWrapper
             control={form.control}
             name="twitter"
+            label="Twitter / X"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Twitter / X</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="https://twitter.com/username"
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+              <Input
+                placeholder="https://twitter.com/username"
+                {...field}
+                value={field.value ?? ""}
+              />
             )}
           />
 
-          <FormField
+          <FormFieldWrapper
             control={form.control}
             name="website"
+            label="Personal Website"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Personal Website</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="https://yoursite.com"
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+              <Input
+                placeholder="https://yoursite.com"
+                {...field}
+                value={field.value ?? ""}
+              />
             )}
           />
         </div>

--- a/components/settings/wallet-tab.tsx
+++ b/components/settings/wallet-tab.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Loader2, LogOut, Wallet } from "lucide-react";
+import { useSmartWallet } from "@/components/providers/smart-wallet-provider";
+import { AccountLink } from "@/components/ui/stellar-link";
+
+export function WalletTab() {
+  const { walletInfo, isConnected, isLoading, disconnect } = useSmartWallet();
+  const [confirming, setConfirming] = useState(false);
+
+  const handleDisconnect = async () => {
+    setConfirming(false);
+    await disconnect();
+  };
+
+  if (!isConnected || !walletInfo) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 gap-4 text-center">
+        <Wallet className="h-12 w-12 text-muted-foreground/50" />
+        <div>
+          <p className="font-medium">No wallet connected</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Connect a wallet from the navigation bar to manage it here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-green-500" />
+          <span className="text-sm font-medium">Connected</span>
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground">Wallet Address</p>
+          <AccountLink
+            value={walletInfo.address}
+            maxLength={20}
+            showCopy
+            className="font-mono text-sm rounded-md bg-muted/50 px-3 py-2 border border-border w-full justify-between"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground">Balance</p>
+          <p className="text-lg font-semibold">
+            {walletInfo.balance.toLocaleString()} {walletInfo.balanceCurrency}
+          </p>
+        </div>
+      </div>
+
+      <AlertDialog open={confirming} onOpenChange={setConfirming}>
+        <AlertDialogTrigger asChild>
+          <Button variant="destructive" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Disconnecting...
+              </>
+            ) : (
+              <>
+                <LogOut className="mr-2 h-4 w-4" />
+                Disconnect Wallet
+              </>
+            )}
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect wallet?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your wallet will be disconnected from this session. You can
+              reconnect at any time using your passkey.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDisconnect}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Disconnect
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/hooks/use-user-mutations.ts
+++ b/hooks/use-user-mutations.ts
@@ -1,81 +1,71 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { authClient } from '@/lib/auth-client';
-import { authKeys } from '@/lib/query/query-keys';
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { authClient } from "@/lib/auth-client";
+import { authKeys } from "@/lib/query/query-keys";
 
-/**
- * Parameters for updating user profile
- */
 export interface UpdateUserParams {
-    name?: string;      // User's display name
-    image?: string;     // URL to user's profile image
+  name?: string;
+  image?: string;
+  bio?: string;
+  github?: string;
+  twitter?: string;
+  website?: string;
 }
 
-/**
- * Update user profile information
- * 
- * @param params - User update parameters (name and/or image)
- * @returns Updated user data from Better Auth
- * @throws Error with descriptive message on failure
- */
 export async function updateUser(params: UpdateUserParams) {
-    try {
-        const response = await authClient.updateUser(params);
+  try {
+    const response = await authClient.updateUser(
+      params as Parameters<typeof authClient.updateUser>[0],
+    );
 
-        if (!response.data) {
-            throw new Error('Failed to update user profile');
-        }
-
-        return response.data;
-    } catch (error) {
-        if (error instanceof Error) {
-            throw new Error(`User update failed: ${error.message}`);
-        }
-        throw new Error('An unexpected error occurred while updating user profile');
+    if (!response.data) {
+      throw new Error("Failed to update user profile");
     }
+
+    return response.data;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`User update failed: ${error.message}`);
+    }
+    throw new Error("An unexpected error occurred while updating user profile");
+  }
 }
 
-/**
- * Type for the updated user data returned by the mutation
- */
 export type UpdateUserData = Awaited<ReturnType<typeof updateUser>>;
 
-/**
- * Mutation hook for updating user profile information
- * 
- * Features:
- * - Invalidates session cache on success
- * - Shows success toast notification
- * - Shows error toast notification with error message
- * - Provides loading states and error handling
- * 
- * @example
- * ```tsx
- * const { mutate, isPending, error } = useUpdateUserMutation();
- * 
- * const handleUpdate = () => {
- *   mutate({
- *     name: "John Doe",
- *     image: "https://example.com/avatar.jpg"
- *   });
- * };
- * ```
- */
 export function useUpdateUserMutation() {
-    const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
-    return useMutation({
-        mutationFn: updateUser,
-        onSuccess: () => {
-            // Invalidate session queries to fetch fresh user data
-            queryClient.invalidateQueries({ queryKey: authKeys.session() });
+  return useMutation({
+    mutationFn: updateUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: authKeys.session() });
+      toast.success("Profile updated successfully!");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to update user profile");
+    },
+  });
+}
 
-            // Show success notification
-            toast.success('User updated successfully!');
-        },
-        onError: (error: Error) => {
-            // Show error notification with descriptive message
-            toast.error(error.message || 'Failed to update user profile');
-        },
-    });
+async function deleteAccount() {
+  const response = await authClient.deleteUser();
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to delete account");
+  }
+  return response.data;
+}
+
+export function useDeleteAccountMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteAccount,
+    onSuccess: () => {
+      queryClient.clear();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to delete account");
+    },
+  });
 }

--- a/hooks/use-user-mutations.ts
+++ b/hooks/use-user-mutations.ts
@@ -13,22 +13,19 @@ export interface UpdateUserParams {
 }
 
 export async function updateUser(params: UpdateUserParams) {
-  try {
-    const response = await authClient.updateUser(
-      params as Parameters<typeof authClient.updateUser>[0],
-    );
+  const response = await authClient.updateUser(
+    params as Parameters<typeof authClient.updateUser>[0],
+  );
 
-    if (!response.data) {
-      throw new Error("Failed to update user profile");
-    }
-
-    return response.data;
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new Error(`User update failed: ${error.message}`);
-    }
-    throw new Error("An unexpected error occurred while updating user profile");
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to update user profile");
   }
+
+  if (!response.data) {
+    throw new Error("Failed to update user profile");
+  }
+
+  return response.data;
 }
 
 export type UpdateUserData = Awaited<ReturnType<typeof updateUser>>;

--- a/hooks/use-user-mutations.ts
+++ b/hooks/use-user-mutations.ts
@@ -13,9 +13,7 @@ export interface UpdateUserParams {
 }
 
 export async function updateUser(params: UpdateUserParams) {
-  const response = await authClient.updateUser(
-    params as Parameters<typeof authClient.updateUser>[0],
-  );
+  const response = await authClient.updateUser(params);
 
   if (response.error) {
     throw new Error(response.error.message || "Failed to update user profile");

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -1,10 +1,26 @@
 import { createAuthClient } from "better-auth/react";
-import { magicLinkClient } from "better-auth/client/plugins";
+import {
+  magicLinkClient,
+  inferAdditionalFields,
+} from "better-auth/client/plugins";
 
 export const authClient = createAuthClient({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
   cookiePrefix: "boundless_auth",
-  plugins: [magicLinkClient()],
+  plugins: [
+    magicLinkClient(),
+    // Mirror the user.additionalFields configured on the better-auth backend
+    // so authClient.updateUser is typed for these fields and no cast is
+    // needed in use-user-mutations.ts.
+    inferAdditionalFields({
+      user: {
+        bio: { type: "string", required: false },
+        github: { type: "string", required: false },
+        twitter: { type: "string", required: false },
+        website: { type: "string", required: false },
+      },
+    }),
+  ],
 });
 
 const errorMessages: Record<string, string> = Object.fromEntries(

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -6,6 +6,10 @@ export interface User {
   name: string;
   email?: string;
   image?: string;
+  bio?: string;
+  github?: string;
+  twitter?: string;
+  website?: string;
 }
 
 interface SessionUser {
@@ -96,11 +100,22 @@ export async function getCurrentUser(): Promise<User | null> {
       return null;
     }
 
+    const u = validatedSession.user as typeof validatedSession.user & {
+      bio?: string | null;
+      github?: string | null;
+      twitter?: string | null;
+      website?: string | null;
+    };
+
     return {
-      id: validatedSession.user.id,
-      name: validatedSession.user.name ?? "Authenticated User",
-      email: validatedSession.user.email ?? undefined,
-      image: validatedSession.user.image ?? undefined,
+      id: u.id!,
+      name: u.name ?? "Authenticated User",
+      email: u.email ?? undefined,
+      image: u.image ?? undefined,
+      bio: u.bio ?? undefined,
+      github: u.github ?? undefined,
+      twitter: u.twitter ?? undefined,
+      website: u.website ?? undefined,
     };
   } catch (error) {
     console.error("Failed to resolve current user from session:", error);

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -107,8 +107,11 @@ export async function getCurrentUser(): Promise<User | null> {
       website?: string | null;
     };
 
+    const id = u.id;
+    if (!id) return null;
+
     return {
-      id: u.id!,
+      id,
       name: u.name ?? "Authenticated User",
       email: u.email ?? undefined,
       image: u.image ?? undefined,


### PR DESCRIPTION
  Summary

  - Add /settings route protected by server-side auth guard (redirects unauthenticated users to /auth)
  - Profile tab edit display name, avatar URL, bio, and social links (GitHub, Twitter, personal website) with inline
  zod validation and optimistic update with rollback on error
  - Notifications tab per-event-type in-app/email toggles and email digest cadence (off/daily/weekly)
  - Wallet tab shows connected wallet address and balance; disconnect requires AlertDialog confirmation
  - Danger Zone tab delete account with double-confirm (user must type delete my account exactly before button
  enables)
  - Extend hooks/use-user-mutations.ts with bio, github, twitter, website fields on UpdateUserParams and add
  useDeleteAccountMutation

  Files Created

  - app/settings/page.tsx — server component with auth guard
  - app/settings/settings-client.tsx — tabbed shell
  - components/settings/profile-tab.tsx
  - components/settings/notifications-tab.tsx
  - components/settings/wallet-tab.tsx
  - components/settings/danger-zone-tab.tsx

  Files Modified

  - hooks/use-user-mutations.ts extended profile fields + delete account mutation

  Test plan

  - Visit /settings while logged out should redirect to /auth
  - Visit /settings while logged in all four tabs render
  - Profile tab: submit with empty name inline error appears (no toast)
  - Profile tab: submit valid data optimistic update applies, success toast shown
  - Wallet tab: click Disconnect confirmation dialog appears before action fires
  - Danger Zone: confirm button stays disabled until delete my account is typed exactly



closes #183 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Settings page titled "Settings" (requires sign-in; unauthenticated users redirected to sign-in) with Profile, Notifications, Wallet, and Danger Zone tabs.
  * Profile: update name, bio, avatar and social/website links (validation, optimistic save).
  * Notifications: configure in-app/email channels and digest cadence; save preferences.
  * Wallet: connect, view address/balance, copy address, and disconnect.
  * Danger Zone: account deletion requires exact confirmation phrase and final confirmation; clears session on success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->