### PR TITLE
Add optional bounty UI fields

### DIFF
--- a/components/bounty-detail/bounty-detail-client.tsx
+++ b/components/bounty-detail/bounty-detail-client.tsx
@@ -28,7 +28,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MilestoneSubmissionCard } from "./milestone-submission-card";
 import { Model4MaintainerDashboard } from "./model4-maintainer-dashboard";
-import type { Milestone, ContributorProgress } from "@/types/bounty";
+import type { Bounty, Milestone, ContributorProgress } from "@/types/bounty";
 import {
   ApplicationReviewDashboard,
   type Application,
@@ -36,7 +36,8 @@ import {
 import { SubmissionApprovalPanel } from "@/components/bounty/submission-approval-panel";
 import { ApplicationSubmitWorkPanel } from "@/components/bounty/application-submit-work-panel";
 
-type BountyData = ReturnType<typeof useBountyDetail>["data"];
+type BountyData = (ReturnType<typeof useBountyDetail>["data"] &
+  Partial<Bounty>) | null | undefined;
 
 /** Returns milestones with mock fallback. Safe for public display since
  * milestones are structural (titles/descriptions), not personal data.
@@ -71,10 +72,7 @@ function getFullMilestoneData(bounty: BountyData): {
 // Backend does not currently provide applications in the response.
 // Fall back to empty array until the schema supports it.
 const getApplications = (bounty: BountyData): Application[] => {
-  return (
-    (bounty as BountyData & { applications?: Application[] })?.applications ??
-    []
-  );
+  return bounty?.applications ?? [];
 };
 
 export function BountyDetailClient({ bountyId }: { bountyId: string }) {

--- a/components/bounty-detail/bounty-detail-sidebar-cta.tsx
+++ b/components/bounty-detail/bounty-detail-sidebar-cta.tsx
@@ -77,9 +77,8 @@ export function SidebarCTA({ bounty, onCancelled }: SidebarCTAProps) {
   const canCancel =
     isCreator && (bounty.status === "OPEN" || bounty.status === "IN_PROGRESS");
 
-  // Fall back to _count.submissions until backend adds claimCount / maxParticipants
-  const claimCount = bounty._count?.submissions ?? 0;
-  const maxParticipants: number | null = null;
+  const claimCount = bounty.claimCount ?? bounty._count?.submissions ?? 0;
+  const maxParticipants = bounty.maxParticipants ?? null;
   const deadline = bounty.bountyWindow?.endDate ?? null;
   const isFinalized = bounty.status === "COMPLETED";
   const submissionCount = bounty._count?.submissions ?? 0;

--- a/types/bounty.ts
+++ b/types/bounty.ts
@@ -65,6 +65,39 @@ export interface BountySubmission {
   updatedAt: string;
 }
 
+export type BountyApplicationStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "disputed";
+
+export interface BountyApplication {
+  id: string;
+  bountyId: string;
+  applicantId?: string | null;
+  applicantAddress: string;
+  applicantName?: string;
+  applicantAvatarUrl?: string | null;
+  coverLetter?: string | null;
+  portfolioUrl?: string | null;
+  proposal: {
+    approach: string;
+    estimatedTimeline: string;
+    relevantExperience: string;
+    portfolioUrl?: string;
+  };
+  reputation: {
+    score: number;
+    tier: string;
+    completionStats: string;
+  };
+  status: BountyApplicationStatus;
+  createdAt: string;
+  submittedAt: string;
+  reviewedAt?: string | null;
+  feedback?: string | null;
+}
+
 export interface BountyCount {
   submissions: number;
 }
@@ -105,7 +138,10 @@ export interface Bounty {
   bountyWindow?: BountyWindowType | null;
 
   submissions?: BountySubmission[] | null;
+  applications?: BountyApplication[] | null;
   _count?: BountyCount | null;
+  claimCount?: number | null;
+  maxParticipants?: number | null;
 
   milestones?: Milestone[] | null;
   contributorProgress?: ContributorProgress[] | null;


### PR DESCRIPTION
## Summary
- closes #211
- adds optional UI-only bounty fields for applications, claim counts, and max participants
- removes remaining ad-hoc casts from the bounty detail client/sidebar paths and uses the shared Bounty type instead

## Verification
- `git diff --check`

Note: full TypeScript/lint verification could not be completed locally because dependency installation failed on this machine. `npm ci` is blocked by the upstream lockfile being out of sync (`bufferutil` missing), and both `npm install` / `pnpm install` hit registry TLS/ECONNRESET failures before creating local binaries.