### PR TITLE
Add email digest preview to notification settings

### DIFF
--- a/components/settings/notifications-tab.tsx
+++ b/components/settings/notifications-tab.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
@@ -11,9 +19,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2 } from "lucide-react";
+import { Loader2, MailOpen } from "lucide-react";
 import { toast } from "sonner";
 import { Separator } from "@/components/ui/separator";
+import { authClient } from "@/lib/auth-client";
+import {
+  useNotifications,
+  type NotificationItem,
+  type NotificationType,
+} from "@/hooks/use-notifications";
 
 interface NotificationPrefs {
   newBounty: { inApp: boolean; email: boolean };
@@ -53,9 +67,57 @@ const eventLabels: Record<
   mentions: "Mentions and replies",
 };
 
+const digestTypeLabels: Record<NotificationType, string> = {
+  "bounty-updated": "New bounties",
+  "saved-bounty-updated": "New bounties",
+  "new-application": "Application updates",
+  "submission-reviewed": "Application updates",
+};
+
+const digestGroupOrder = [
+  "New bounties",
+  "Application updates",
+  "Bounty completed",
+  "Mentions and replies",
+] as const;
+
+function formatDigestTime(timestamp: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
 export function NotificationsTab() {
   const [prefs, setPrefs] = useState<NotificationPrefs>(loadPrefs);
   const [isPending, setIsPending] = useState(false);
+  const { data: session } = authClient.useSession();
+  const { notifications } = useNotifications();
+
+  const digestGroups = useMemo(() => {
+    const groups = new Map<string, NotificationItem[]>();
+
+    for (const item of notifications) {
+      const label = digestTypeLabels[item.type];
+      if (!label) continue;
+
+      const current = groups.get(label) ?? [];
+      if (current.length < 3) {
+        groups.set(label, [...current, item]);
+      }
+    }
+
+    return digestGroupOrder
+      .map((label) => ({ label, items: groups.get(label) ?? [] }))
+      .filter((group) => group.items.length > 0);
+  }, [notifications]);
+
+  const digestSubtitle =
+    prefs.digestCadence === "weekly"
+      ? "Sent every Monday at 9am"
+      : "Sent every morning at 9am";
 
   const toggleChannel = (
     event: keyof Omit<NotificationPrefs, "digestCadence">,
@@ -117,28 +179,97 @@ export function NotificationsTab() {
 
       <Separator />
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-4">
         <div className="space-y-1">
           <Label>Email digest</Label>
           <p className="text-sm text-muted-foreground">
             Receive a summary of activity at your chosen cadence.
           </p>
         </div>
-        <Select
-          value={prefs.digestCadence}
-          onValueChange={(value: NotificationPrefs["digestCadence"]) =>
-            setPrefs((prev) => ({ ...prev, digestCadence: value }))
-          }
-        >
-          <SelectTrigger className="w-32">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="off">Off</SelectItem>
-            <SelectItem value="daily">Daily</SelectItem>
-            <SelectItem value="weekly">Weekly</SelectItem>
-          </SelectContent>
-        </Select>
+        <div className="flex items-center gap-2">
+          <Select
+            value={prefs.digestCadence}
+            onValueChange={(value: NotificationPrefs["digestCadence"]) =>
+              setPrefs((prev) => ({ ...prev, digestCadence: value }))
+            }
+          >
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="off">Off</SelectItem>
+              <SelectItem value="daily">Daily</SelectItem>
+              <SelectItem value="weekly">Weekly</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={prefs.digestCadence === "off"}
+              >
+                Preview
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>Email digest preview</DialogTitle>
+                <DialogDescription>
+                  A representative {prefs.digestCadence} summary for{" "}
+                  {session?.user?.name ?? "your account"}. {digestSubtitle}.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="rounded-lg border bg-muted/20 p-5">
+                <div className="mb-5 flex items-start gap-3">
+                  <div className="rounded-full bg-background p-2">
+                    <MailOpen className="h-5 w-5 text-muted-foreground" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">
+                      Hi {session?.user?.name ?? "there"},
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Here is your latest Boundless bounty activity.
+                    </p>
+                  </div>
+                </div>
+
+                {digestGroups.length > 0 ? (
+                  <div className="space-y-5">
+                    {digestGroups.map((group) => (
+                      <section key={group.label} className="space-y-2">
+                        <h4 className="text-sm font-semibold">
+                          {group.label}
+                        </h4>
+                        <div className="space-y-2">
+                          {group.items.map((item) => (
+                            <div
+                              key={`${item.type}-${item.id}`}
+                              className="rounded-md border bg-background p-3"
+                            >
+                              <p className="text-sm">{item.message}</p>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {formatDigestTime(item.timestamp)}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+                      </section>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
+                    Recent notification activity will appear here before each
+                    digest is sent.
+                  </p>
+                )}
+              </div>
+            </DialogContent>
+          </Dialog>
+        </div>
       </div>
 
       <Button onClick={handleSave} disabled={isPending}>

--- a/components/settings/notifications-tab.tsx
+++ b/components/settings/notifications-tab.tsx
@@ -68,9 +68,12 @@ const eventLabels: Record<
 };
 
 const digestTypeLabels: Record<NotificationType, string> = {
+  "bounty-completed": "Bounty completed",
   "bounty-updated": "New bounties",
+  mention: "Mentions and replies",
   "saved-bounty-updated": "New bounties",
   "new-application": "Application updates",
+  reply: "Mentions and replies",
   "submission-reviewed": "Application updates",
 };
 

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -21,7 +21,10 @@ import { useGraphQLSubscription } from "./use-graphql-subscription";
 
 export type NotificationType =
   | "bounty-updated"
+  | "bounty-completed"
+  | "mention"
   | "new-application"
+  | "reply"
   | "submission-reviewed"
   | "saved-bounty-updated";
 


### PR DESCRIPTION
## Summary
- closes #206
- adds a Preview button beside the email digest cadence selector
- disables preview while cadence is Off
- opens a dialog with the user name, cadence-specific send schedule, and grouped recent notifications from `useNotifications`
- skips empty groups and caps each rendered group to three items for a realistic digest preview

## Verification
- `git diff --check`

Note: full TypeScript/lint verification could not be completed locally because dependency installation failed on this machine. `npm ci` is blocked by the upstream lockfile being out of sync (`bufferutil` missing), and both `npm install` / `pnpm install` hit registry TLS/ECONNRESET failures before creating local binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email digest preview: Notification settings include a preview dialog showing grouped notifications, formatted timestamps, and cadence-specific subtitles; preview is disabled when cadence is off and shows an empty state if no items.
  * Expanded notification types: Digests and settings now include support for additional notification kinds (e.g., bounties and replies).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->