### PR TITLE
Extend Bounty type optional fields; remove ad-hoc submissions casts

### DIFF
--- a/hooks/use-competition-join-state.ts
+++ b/hooks/use-competition-join-state.ts
@@ -39,7 +39,7 @@ export function useCompetitionJoinState(
   // BountyFieldsFragment (list queries) doesn't include submissions, so falls
   // back to false until the detail query resolves.
   const bountySubmissions = (
-    bounty as { submissions?: Array<{ submittedBy: string }> | null }
+    bounty
   ).submissions;
   const serverHasJoined =
     walletAddress != null &&

--- a/types/bounty.ts
+++ b/types/bounty.ts
@@ -69,6 +69,15 @@ export interface BountyCount {
   submissions: number;
 }
 
+export interface BountyApplication {
+  id: string;
+  bountyId: string;
+  appliedBy: string;
+  status?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface Milestone {
   id: string;
   title: string;
@@ -105,13 +114,14 @@ export interface Bounty {
   bountyWindow?: BountyWindowType | null;
 
   submissions?: BountySubmission[] | null;
-  _count?: BountyCount | null;
-
-  milestones?: Milestone[] | null;
-  contributorProgress?: ContributorProgress[] | null;
-
+  applications?: BountyApplication[] | null;
+  claimCount?: number | null;
+  maxParticipants?: number | null;
   maxSlots?: number | null;
   totalSlotsOccupied?: number | null;
+  milestones?: Milestone[] | null;
+  contributorProgress?: ContributorProgress[] | null;
+  _count?: BountyCount | null;
 
   createdBy: string;
   createdAt: string;


### PR DESCRIPTION
Summary:
- add missing optional fields on Bounty (applications, claimCount, maxParticipants, maxSlots, totalSlotsOccupied, milestones, contributorProgress)
- add BountyApplication interface in types/bounty.ts
- remove ad-hoc cast in use-competition-join-state and read bounty.submissions directly

Validation:
- pnpm tsc --noEmit (cannot run here: pnpm not installed)
- pnpm lint (cannot run here: pnpm not installed)

No behavior change intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bounty applications in the bounty system.

* **Refactor**
  * Improved type safety and removed unnecessary type assertions in the competition join state logic for cleaner code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->