### PR TITLE
Add empty state for saved bounties

### DIFF
--- a/app/saved/saved-client.tsx
+++ b/app/saved/saved-client.tsx
@@ -44,16 +44,19 @@ function SavedBountiesClient() {
 
   if (bookmarkedBounties.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="rounded-full bg-muted p-4 mb-4">
-          <Bookmark className="h-8 w-8 text-muted-foreground" />
+      <div className="flex flex-col items-center justify-center py-24 text-center border border-dashed border-gray-800 rounded-2xl bg-background-card/30">
+        <div className="mb-4 flex size-16 items-center justify-center rounded-full bg-gray-800/50">
+          <Bookmark className="size-8 text-gray-600" />
         </div>
-        <h2 className="text-xl font-semibold mb-2">No saved bounties yet</h2>
-        <p className="text-muted-foreground max-w-sm mb-6">
-          Bookmark interesting bounties to save them here for later review.
+        <h2 className="mb-2 text-xl font-bold text-gray-200">
+          No saved bounties yet
+        </h2>
+        <p className="mx-auto mb-6 max-w-md text-gray-400">
+          Bounties you bookmark will show up here so you can find them again
+          quickly.
         </p>
         <Button asChild>
-          <Link href="/">Explore Bounties</Link>
+          <Link href="/bounty">Browse bounties</Link>
         </Button>
       </div>
     );


### PR DESCRIPTION
## Summary

* Added a proper empty state for `/saved` when the user has no saved bounties.
* Kept the existing loading skeleton behavior unchanged.
* Updated the empty state CTA to link to `/bounty`.
* Kept the change scoped to `app/saved/saved-client.tsx`.

## Files changed

* `app/saved/saved-client.tsx`

## Verification

* `pnpm install` — passed
* `pnpm lint` — passed with one existing unrelated warning in `lib/server-graphql.ts`
* `pnpm test` — passed: 14 test suites, 81 tests
* `git diff --check` — passed

## Demo

* Empty `/saved` now renders a centered empty-state card.
* The card includes a Bookmark icon, `No saved bounties yet` heading, explanatory copy, and a `Browse bounties` CTA linking to `/bounty`.

Closes #213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the empty-state experience when no bounties are saved, including updated messaging and clearer description text to better guide users.
  * Updated the primary navigation link to direct users to the correct destination for browsing available bounties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->