### PR TITLE
Implement request revisions flow for bounty submissions

### DIFF
--- a/components/bounty-detail/bounty-detail-client.tsx
+++ b/components/bounty-detail/bounty-detail-client.tsx
@@ -246,6 +246,7 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
             <ApplicationSubmitWorkPanel
               bountyId={bountyId}
               contributorAddress={walletAddress}
+              revisionFeedback={bounty.submissions?.[0]?.reviewComments || undefined}
             />
           )}
 
@@ -255,8 +256,12 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
             <SubmissionApprovalPanel
               bounty={bounty}
               creatorAddress={walletAddress}
+              submissionId={bounty.submissions?.[0]?.id || undefined}
               submittedWorkCid={
                 bounty.submissions?.[0]?.githubPullRequestUrl || undefined
+              }
+              submissionDescription={
+                bounty.submissions?.[0]?.reviewComments || undefined
               }
             />
           )}

--- a/components/bounty/application-submit-work-panel.tsx
+++ b/components/bounty/application-submit-work-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Upload, Link as LinkIcon, Send } from "lucide-react";
+import { Upload, Link as LinkIcon, Send, AlertTriangle } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -17,11 +17,13 @@ import { useSubmitApplicationWork } from "@/hooks/use-bounty-application";
 interface ApplicationSubmitWorkPanelProps {
   bountyId: string;
   contributorAddress: string;
+  revisionFeedback?: string;
 }
 
 export function ApplicationSubmitWorkPanel({
   bountyId,
   contributorAddress,
+  revisionFeedback,
 }: ApplicationSubmitWorkPanelProps) {
   const [workCid, setWorkCid] = useState("");
 
@@ -51,6 +53,17 @@ export function ApplicationSubmitWorkPanel({
         </CardDescription>
       </CardHeader>
       <CardContent className="pt-6">
+        {revisionFeedback && (
+          <div className="mb-6 rounded-lg border border-amber-500/20 bg-amber-500/10 p-4 text-sm text-amber-100">
+            <div className="flex items-center gap-2 font-medium text-amber-200 mb-2">
+              <AlertTriangle className="size-4" />
+              Revision requested
+            </div>
+            <p className="whitespace-pre-wrap text-amber-100/80">
+              {revisionFeedback}
+            </p>
+          </div>
+        )}
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
             <Label htmlFor="work-cid">

--- a/components/bounty/submission-approval-panel.tsx
+++ b/components/bounty/submission-approval-panel.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   ExternalLink,
   ShieldCheck,
+  Loader2,
 } from "lucide-react";
 import {
   Card,
@@ -18,7 +19,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { useApproveApplicationSubmission } from "@/hooks/use-bounty-application";
+import {
+  useApproveApplicationSubmission,
+  useRequestRevisions,
+} from "@/hooks/use-bounty-application";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
 import type { BountyFieldsFragment } from "@/lib/graphql/generated";
 import type { Bounty } from "@/types/bounty";
 
@@ -29,6 +35,7 @@ interface SubmissionApprovalPanelProps {
   creatorAddress: string;
   submittedWorkCid?: string;
   submissionDescription?: string;
+  submissionId?: string;
 }
 
 export function SubmissionApprovalPanel({
@@ -36,11 +43,16 @@ export function SubmissionApprovalPanel({
   creatorAddress,
   submittedWorkCid,
   submissionDescription,
+  submissionId,
 }: SubmissionApprovalPanelProps) {
   const [points, setPoints] = useState<number>(5);
+  const [showRevisionForm, setShowRevisionForm] = useState(false);
+  const [revisionFeedback, setRevisionFeedback] = useState("");
 
   const { mutate: approveSubmission, isPending: isApproving } =
     useApproveApplicationSubmission();
+  const { mutate: requestRevisions, isPending: isRequestingRevisions } =
+    useRequestRevisions();
 
   const handleApprove = () => {
     const clampedPoints = Math.max(1, Math.min(100, points || 0));
@@ -49,6 +61,31 @@ export function SubmissionApprovalPanel({
       creatorAddress,
       points: clampedPoints,
     });
+  };
+
+  const handleRequestRevisions = () => {
+    if (!submissionId || !revisionFeedback.trim()) return;
+    requestRevisions(
+      {
+        bountyId: bounty.id,
+        submissionId,
+        feedback: revisionFeedback.trim(),
+      },
+      {
+        onSuccess: () => {
+          toast.success("Revision request sent to contributor.");
+          setRevisionFeedback("");
+          setShowRevisionForm(false);
+        },
+        onError: (error) => {
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Failed to request revisions.",
+          );
+        },
+      },
+    );
   };
 
   return (
@@ -131,24 +168,69 @@ export function SubmissionApprovalPanel({
             </Button>
           </div>
 
-          {/* Revision Section - Coming Soon */}
           <div className="space-y-4 border-l border-gray-800/50 pl-6">
-            <div className="h-full flex flex-col justify-center items-center text-center p-4 border border-dashed border-gray-800 rounded-lg opacity-60">
-              <AlertTriangle className="size-6 text-gray-500 mb-2" />
-              <h4 className="text-sm font-medium text-gray-400 mb-1">
-                Needs Changes?
-              </h4>
-              <p className="text-xs text-gray-500 mb-4">
-                Request revisions before releasing the escrow.
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="border-gray-700 text-gray-500 cursor-not-allowed"
-                disabled
-              >
-                Coming Soon
-              </Button>
+            <div className="space-y-4 p-4 border border-dashed border-amber-500/20 rounded-lg bg-amber-500/5">
+              <div className="text-center">
+                <AlertTriangle className="size-6 text-amber-400 mb-2 mx-auto" />
+                <h4 className="text-sm font-medium text-amber-200 mb-1">
+                  Needs Changes?
+                </h4>
+                <p className="text-xs text-amber-500/80">
+                  Send feedback before releasing the escrow.
+                </p>
+              </div>
+
+              {showRevisionForm ? (
+                <div className="space-y-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="revision-feedback">Revision feedback</Label>
+                    <Textarea
+                      id="revision-feedback"
+                      value={revisionFeedback}
+                      onChange={(e) => setRevisionFeedback(e.target.value)}
+                      placeholder="Explain what needs to change before approval..."
+                      className="min-h-24 bg-background-card"
+                      disabled={isRequestingRevisions}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="flex-1"
+                      onClick={() => setShowRevisionForm(false)}
+                      disabled={isRequestingRevisions}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="flex-1"
+                      onClick={handleRequestRevisions}
+                      disabled={
+                        !submissionId ||
+                        !revisionFeedback.trim() ||
+                        isRequestingRevisions
+                      }
+                    >
+                      {isRequestingRevisions && (
+                        <Loader2 className="size-4 mr-2 animate-spin" />
+                      )}
+                      Send Request
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full border-amber-500/30 text-amber-300 hover:bg-amber-500/10"
+                  onClick={() => setShowRevisionForm(true)}
+                  disabled={!submissionId || isApproving}
+                >
+                  Request Revisions
+                </Button>
+              )}
             </div>
           </div>
         </div>

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -29,6 +29,11 @@ type ApplicationContractClient = {
     bountyId: bigint;
     points: number;
   }) => Promise<{ txHash: string }>;
+  requestRevisions: (params: {
+    bountyId: bigint;
+    submissionId: string;
+    feedback: string;
+  }) => Promise<{ txHash: string }>;
 };
 
 // ---------------------------------------------------------------------------
@@ -234,6 +239,66 @@ export function useApproveApplicationSubmission() {
             ...prev.bounty,
             status: "COMPLETED",
             updatedAt: new Date().toISOString(),
+          },
+        });
+      }
+      return { prev, bountyId };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(bountyKeys.detail(ctx.bountyId), ctx.prev);
+    },
+    onSettled: (_r, _e, v) => {
+      qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
+      qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+    },
+  });
+}
+
+
+// ---------------------------------------------------------------------------
+// Hook: request revisions
+// ---------------------------------------------------------------------------
+
+export function useRequestRevisions() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      bountyId,
+      submissionId,
+      feedback,
+    }: {
+      bountyId: string;
+      submissionId: string;
+      feedback: string;
+    }) => {
+      const client = resolveApplicationClient();
+      return client.requestRevisions({
+        bountyId: toBountyIdBigInt(bountyId),
+        submissionId,
+        feedback,
+      });
+    },
+    onMutate: async ({ bountyId, submissionId, feedback }) => {
+      await qc.cancelQueries({ queryKey: bountyKeys.detail(bountyId) });
+      const prev = qc.getQueryData<BountyQuery>(bountyKeys.detail(bountyId));
+      if (prev?.bounty) {
+        qc.setQueryData<BountyQuery>(bountyKeys.detail(bountyId), {
+          ...prev,
+          bounty: {
+            ...prev.bounty,
+            status: "UNDER_REVIEW",
+            updatedAt: new Date().toISOString(),
+            submissions: prev.bounty.submissions?.map((submission) =>
+              submission.id === submissionId
+                ? {
+                    ...submission,
+                    status: "REVISION_REQUESTED",
+                    reviewComments: feedback,
+                    reviewedAt: new Date().toISOString(),
+                  }
+                : submission,
+            ),
           },
         });
       }


### PR DESCRIPTION
## Summary

Closes #202.

Implements the Request Revisions path for the milestone submission approval flow.

## Changes

- Added `useRequestRevisions` in `hooks/use-bounty-application.ts`
  - accepts `bountyId`, `submissionId`, and `feedback`
  - calls `client.requestRevisions(...)`
  - optimistically keeps the bounty in `UNDER_REVIEW`
  - stores feedback on the matching submission as `reviewComments`
  - rolls back on mutation error and invalidates detail/list queries on settle
- Re-enabled the Request Revisions action in `submission-approval-panel.tsx`
  - reveals a feedback textarea
  - submits feedback through the new mutation
  - shows success/error toast
  - resets the panel on success
- Surfaces latest revision feedback in `application-submit-work-panel.tsx`
- Passes submission id and feedback from `bounty-detail-client.tsx`

## Verification

- Static balance check across changed TS/TSX files:
  - braces balanced
  - parentheses balanced
- Confirmed all requested touchpoints are updated:
  - `hooks/use-bounty-application.ts`
  - `components/bounty/submission-approval-panel.tsx`
  - `components/bounty/application-submit-work-panel.tsx`
  - `components/bounty-detail/bounty-detail-client.tsx`

## Notes

I could not run the full local app test suite from this environment because dependency installation/cloning has been intermittently timing out, so this PR keeps the change scoped to the requested flow and follows the existing optimistic mutation pattern used by `useApproveApplicationSubmission`.
