### PR TITLE
Add empty state for saved bounties

### DIFF
--- a/app/saved/saved-client.tsx
+++ b/app/saved/saved-client.tsx
@@ -44,16 +44,18 @@ function SavedBountiesClient() {
 
   if (bookmarkedBounties.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="rounded-full bg-muted p-4 mb-4">
-          <Bookmark className="h-8 w-8 text-muted-foreground" />
+      <div className="flex flex-col items-center justify-center py-24 text-center border border-dashed border-gray-800 rounded-2xl bg-background-card/30">
+        <div className="size-16 rounded-full bg-gray-800/50 flex items-center justify-center mb-4">
+          <Bookmark className="size-8 text-gray-600" />
         </div>
-        <h2 className="text-xl font-semibold mb-2">No saved bounties yet</h2>
-        <p className="text-muted-foreground max-w-sm mb-6">
+        <h2 className="text-xl font-bold mb-2 text-gray-200">
+          No saved bounties yet
+        </h2>
+        <p className="text-gray-400 max-w-md mx-auto mb-6">
           Bookmark interesting bounties to save them here for later review.
         </p>
         <Button asChild>
-          <Link href="/">Explore Bounties</Link>
+          <Link href="/bounty">Browse bounties</Link>
         </Button>
       </div>
     );


### PR DESCRIPTION
## Summary
- add a styled empty state when /saved has no bookmarked bounties
- match the bounty empty-state treatment with a dashed card, icon, heading, and helper text
- point the CTA to /bounty with the requested "Browse bounties" label

## Verification
- npm.cmd run lint -- app/saved/saved-client.tsx
- npx.cmd tsc --noEmit

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the "Browse" button link in the saved bounties empty state to navigate to the bounty page instead of the homepage.

* **Style**
  * Enhanced the empty-state UI design with improved spacing and padding, replacing the container styling with a dashed bordered, centered card-style presentation for better visual hierarchy and user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->