### PR TITLE
test: add bounty creation e2e coverage

### DIFF
--- a/app/bounty/create/page.tsx
+++ b/app/bounty/create/page.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCreateBounty } from "@/hooks/use-bounty-mutations";
+import { BountyType, type CreateBountyInput } from "@/lib/graphql/generated";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type FormState = {
+  title: string;
+  description: string;
+  organizationId: string;
+  githubIssueUrl: string;
+  type: BountyType;
+  rewardAmount: string;
+  rewardCurrency: string;
+  deadline: string;
+  milestoneTitle: string;
+  competitionSeats: string;
+};
+
+const INITIAL_FORM: FormState = {
+  title: "",
+  description: "",
+  organizationId: "",
+  githubIssueUrl: "",
+  type: BountyType.FixedPrice,
+  rewardAmount: "",
+  rewardCurrency: "XLM",
+  deadline: "",
+  milestoneTitle: "",
+  competitionSeats: "3",
+};
+
+export default function CreateBountyPage() {
+  const router = useRouter();
+  const createBounty = useCreateBounty();
+  const [step, setStep] = useState(1);
+  const [form, setForm] = useState<FormState>(INITIAL_FORM);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const title = useMemo(() => {
+    if (step === 1) return "Bounty details";
+    if (step === 2) return "Reward setup";
+    return "Review bounty";
+  }, [step]);
+
+  const updateField = (field: keyof FormState) => (value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setErrors((current) => ({ ...current, [field]: "" }));
+  };
+
+  const validateStepOne = () => {
+    const nextErrors: Record<string, string> = {};
+    if (!form.title.trim()) nextErrors.title = "Title is required";
+    if (!form.description.trim())
+      nextErrors.description = "Description is required";
+    if (!form.organizationId.trim())
+      nextErrors.organizationId = "Organization is required";
+    if (!form.githubIssueUrl.trim())
+      nextErrors.githubIssueUrl = "GitHub issue URL is required";
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const validateStepTwo = () => {
+    const nextErrors: Record<string, string> = {};
+    const rewardAmount = Number(form.rewardAmount);
+    if (!Number.isFinite(rewardAmount) || rewardAmount <= 0) {
+      nextErrors.rewardAmount = "Reward amount must be greater than 0";
+    }
+    if (!form.rewardCurrency.trim())
+      nextErrors.rewardCurrency = "Currency is required";
+    if (!form.deadline) nextErrors.deadline = "Deadline is required";
+    if (
+      form.type === BountyType.MilestoneBased &&
+      !form.milestoneTitle.trim()
+    ) {
+      nextErrors.milestoneTitle = "Milestone title is required";
+    }
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const goNext = () => {
+    if (step === 1 && !validateStepOne()) return;
+    if (step === 2 && !validateStepTwo()) return;
+    setStep((current) => Math.min(current + 1, 3));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (step < 3) {
+      goNext();
+      return;
+    }
+
+    const input: CreateBountyInput = {
+      title: form.title.trim(),
+      description: form.description.trim(),
+      organizationId: form.organizationId.trim(),
+      githubIssueUrl: form.githubIssueUrl.trim(),
+      type: form.type,
+      rewardAmount: Number(form.rewardAmount),
+      rewardCurrency: form.rewardCurrency,
+    };
+
+    const result = await createBounty.mutateAsync(input);
+    router.push(`/bounty/${result.createBounty.id}`);
+  };
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-8">
+          <p className="text-sm text-muted-foreground">Step {step} of 3</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+            Create Bounty
+          </h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>
+              Add the sponsor-side information contributors need before this
+              bounty goes live.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              {step === 1 && (
+                <section className="space-y-5" data-testid="create-step-1">
+                  <div className="space-y-2">
+                    <Label htmlFor="title">Title</Label>
+                    <Input
+                      id="title"
+                      value={form.title}
+                      onChange={(event) =>
+                        updateField("title")(event.target.value)
+                      }
+                      aria-invalid={Boolean(errors.title)}
+                    />
+                    {errors.title && (
+                      <p className="text-sm text-destructive">{errors.title}</p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="description">Description</Label>
+                    <Textarea
+                      id="description"
+                      value={form.description}
+                      onChange={(event) =>
+                        updateField("description")(event.target.value)
+                      }
+                      aria-invalid={Boolean(errors.description)}
+                    />
+                    {errors.description && (
+                      <p className="text-sm text-destructive">
+                        {errors.description}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="grid gap-5 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="organization">Organization</Label>
+                      <Input
+                        id="organization"
+                        value={form.organizationId}
+                        onChange={(event) =>
+                          updateField("organizationId")(event.target.value)
+                        }
+                        aria-invalid={Boolean(errors.organizationId)}
+                      />
+                      {errors.organizationId && (
+                        <p className="text-sm text-destructive">
+                          {errors.organizationId}
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="githubIssueUrl">GitHub URL</Label>
+                      <Input
+                        id="githubIssueUrl"
+                        type="url"
+                        value={form.githubIssueUrl}
+                        onChange={(event) =>
+                          updateField("githubIssueUrl")(event.target.value)
+                        }
+                        aria-invalid={Boolean(errors.githubIssueUrl)}
+                      />
+                      {errors.githubIssueUrl && (
+                        <p className="text-sm text-destructive">
+                          {errors.githubIssueUrl}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label>Bounty type</Label>
+                    <Select
+                      value={form.type}
+                      onValueChange={(value) => updateField("type")(value)}
+                    >
+                      <SelectTrigger aria-label="Bounty type">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={BountyType.FixedPrice}>
+                          Fixed Price
+                        </SelectItem>
+                        <SelectItem value={BountyType.Competition}>
+                          Competition
+                        </SelectItem>
+                        <SelectItem value={BountyType.MilestoneBased}>
+                          Milestone Based
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </section>
+              )}
+
+              {step === 2 && (
+                <section className="space-y-5" data-testid="create-step-2">
+                  <div className="grid gap-5 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="rewardAmount">Reward amount</Label>
+                      <Input
+                        id="rewardAmount"
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={form.rewardAmount}
+                        onChange={(event) =>
+                          updateField("rewardAmount")(event.target.value)
+                        }
+                        aria-invalid={Boolean(errors.rewardAmount)}
+                      />
+                      {errors.rewardAmount && (
+                        <p className="text-sm text-destructive">
+                          {errors.rewardAmount}
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label>Currency</Label>
+                      <Select
+                        value={form.rewardCurrency}
+                        onValueChange={(value) =>
+                          updateField("rewardCurrency")(value)
+                        }
+                      >
+                        <SelectTrigger aria-label="Currency">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="XLM">XLM</SelectItem>
+                          <SelectItem value="USDC">USDC</SelectItem>
+                          <SelectItem value="AQUA">AQUA</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {errors.rewardCurrency && (
+                        <p className="text-sm text-destructive">
+                          {errors.rewardCurrency}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="deadline">Deadline</Label>
+                    <Input
+                      id="deadline"
+                      type="date"
+                      value={form.deadline}
+                      onChange={(event) =>
+                        updateField("deadline")(event.target.value)
+                      }
+                      aria-invalid={Boolean(errors.deadline)}
+                    />
+                    {errors.deadline && (
+                      <p className="text-sm text-destructive">
+                        {errors.deadline}
+                      </p>
+                    )}
+                  </div>
+
+                  {form.type === BountyType.MilestoneBased && (
+                    <div className="space-y-2">
+                      <Label htmlFor="milestoneTitle">Milestone title</Label>
+                      <Input
+                        id="milestoneTitle"
+                        value={form.milestoneTitle}
+                        onChange={(event) =>
+                          updateField("milestoneTitle")(event.target.value)
+                        }
+                        aria-invalid={Boolean(errors.milestoneTitle)}
+                      />
+                      {errors.milestoneTitle && (
+                        <p className="text-sm text-destructive">
+                          {errors.milestoneTitle}
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  {form.type === BountyType.Competition && (
+                    <div className="space-y-2">
+                      <Label htmlFor="competitionSeats">Winner seats</Label>
+                      <Input
+                        id="competitionSeats"
+                        type="number"
+                        min="1"
+                        value={form.competitionSeats}
+                        onChange={(event) =>
+                          updateField("competitionSeats")(event.target.value)
+                        }
+                      />
+                    </div>
+                  )}
+                </section>
+              )}
+
+              {step === 3 && (
+                <section className="space-y-4" data-testid="create-step-3">
+                  <div className="rounded-md border p-4">
+                    <h2 className="font-medium">{form.title}</h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {form.description}
+                    </p>
+                  </div>
+                  <dl className="grid gap-3 text-sm md:grid-cols-2">
+                    <div>
+                      <dt className="text-muted-foreground">Organization</dt>
+                      <dd>{form.organizationId}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">GitHub URL</dt>
+                      <dd>{form.githubIssueUrl}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Type</dt>
+                      <dd>{form.type}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Reward</dt>
+                      <dd>
+                        {form.rewardAmount} {form.rewardCurrency}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Deadline</dt>
+                      <dd>{form.deadline}</dd>
+                    </div>
+                  </dl>
+                </section>
+              )}
+
+              <div className="flex items-center justify-between pt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setStep((current) => Math.max(current - 1, 1))}
+                  disabled={step === 1 || createBounty.isPending}
+                >
+                  Back
+                </Button>
+                <Button type="submit" disabled={createBounty.isPending}>
+                  {step === 3
+                    ? createBounty.isPending
+                      ? "Creating..."
+                      : "Create"
+                    : "Continue"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/e2e/bounty-creation.spec.ts
+++ b/e2e/bounty-creation.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * E2E: Bounty Creation Flow
+ *
+ * Covers the sponsor-side creation wizard at /bounty/create:
+ *   1. Authenticated navigation
+ *   2. Step 1 details and bounty type
+ *   3. Step 2 reward, currency, deadline, and type-specific fields
+ *   4. Step 3 review and successful CreateBounty mutation redirect
+ *   5. Step 1 validation when title is empty
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+
+const CREATED_BOUNTY_ID = "created-bounty-e2e";
+
+const MOCK_SESSION = {
+  user: {
+    id: "sponsor-e2e-tester",
+    name: "Sponsor E2E Tester",
+    email: "sponsor-e2e@test.com",
+    image: null,
+    walletAddress: "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGYWDOUALPIF5JD4PI21JQ",
+  },
+  session: { token: "fake-e2e-token" },
+};
+
+async function setupMocks(page: Page) {
+  await page.route("**/api/auth/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      url.pathname.endsWith("/get-session") ||
+      url.pathname.endsWith("/session")
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_SESSION),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    }
+  });
+
+  await page.route("**/api/graphql", async (route) => {
+    let body: { operationName?: string; variables?: Record<string, unknown> } =
+      {};
+    try {
+      body = JSON.parse(route.request().postData() ?? "{}") as {
+        operationName?: string;
+        variables?: Record<string, unknown>;
+      };
+    } catch {
+      /* ignore */
+    }
+
+    if (body.operationName === "CreateBounty") {
+      const input = body.variables?.input as Record<string, unknown>;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            createBounty: {
+              __typename: "Bounty",
+              id: CREATED_BOUNTY_ID,
+              title: input.title,
+              description: input.description,
+              status: "OPEN",
+              type: input.type,
+              rewardAmount: input.rewardAmount,
+              rewardCurrency: input.rewardCurrency,
+              createdAt: "2026-05-27T10:00:00Z",
+              updatedAt: "2026-05-27T10:00:00Z",
+              organizationId: input.organizationId,
+              projectId: null,
+              bountyWindowId: null,
+              githubIssueUrl: input.githubIssueUrl,
+              githubIssueNumber: null,
+              createdBy: MOCK_SESSION.user.id,
+              organization: {
+                __typename: "BountyOrganization",
+                id: input.organizationId,
+                name: "Boundless Labs",
+                logo: null,
+                slug: "boundless-labs",
+              },
+              project: null,
+              bountyWindow: null,
+              _count: { __typename: "BountyCount", submissions: 0 },
+              submissions: [],
+            },
+          },
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: {} }),
+    });
+  });
+
+  await page.context().addCookies([
+    {
+      name: "boundless_auth.session_token",
+      value: "fake-e2e-token",
+      domain: "localhost",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+test.describe("Bounty creation flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+  });
+
+  test("creates a competition bounty and redirects to the new detail page", async ({
+    page,
+  }) => {
+    await page.goto("/bounty/create");
+
+    await expect(
+      page.getByRole("heading", { name: "Create Bounty" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("create-step-1")).toBeVisible();
+
+    await page.getByLabel("Title").fill("Add sponsor onboarding checklist");
+    await page
+      .getByLabel("Description")
+      .fill("Build a reliable checklist for new sponsor onboarding.");
+    await page.getByLabel("Organization").fill("org-boundless-labs");
+    await page
+      .getByLabel("GitHub URL")
+      .fill("https://github.com/boundlessfi/bounties/issues/215");
+    await page.getByLabel("Bounty type").click();
+    await page.getByRole("option", { name: "Competition" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(page.getByTestId("create-step-2")).toBeVisible();
+    await page.getByLabel("Reward amount").fill("1500");
+    await page.getByLabel("Currency").click();
+    await page.getByRole("option", { name: "USDC" }).click();
+    await page.getByLabel("Deadline").fill("2026-12-31");
+    await page.getByLabel("Winner seats").fill("5");
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(page.getByTestId("create-step-3")).toBeVisible();
+    await expect(
+      page.getByText("Add sponsor onboarding checklist"),
+    ).toBeVisible();
+    await expect(page.getByText("1500 USDC")).toBeVisible();
+
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page).toHaveURL(`/bounty/${CREATED_BOUNTY_ID}`, {
+      timeout: 10_000,
+    });
+  });
+
+  test("keeps users on step 1 and shows title validation when title is empty", async ({
+    page,
+  }) => {
+    await page.goto("/bounty/create");
+
+    await page
+      .getByLabel("Description")
+      .fill("Build a reliable checklist for new sponsor onboarding.");
+    await page.getByLabel("Organization").fill("org-boundless-labs");
+    await page
+      .getByLabel("GitHub URL")
+      .fill("https://github.com/boundlessfi/bounties/issues/215");
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(page.getByTestId("create-step-1")).toBeVisible();
+    await expect(page.getByText("Title is required")).toBeVisible();
+    await expect(page.getByTestId("create-step-2")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #215.

## Summary
- add a sponsor-side `/bounty/create` three-step creation flow wired to `CreateBounty`
- add Playwright coverage for happy-path creation and step-one title validation
- mock auth and GraphQL following the existing bounty application e2e pattern

## Verification
- `npm run lint`
- `npm exec -- prettier --check app/bounty/create/page.tsx e2e/bounty-creation.spec.ts`
- `pnpm exec playwright test e2e/bounty-creation.spec.ts`
- `npm run build` (pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 3-step bounty creation wizard with form validation and per-field error messaging.
  * Supports setting reward amounts, currencies, deadlines, and competition options.
  * Automatically navigates to the new bounty details page upon successful creation.

* **Tests**
  * Added E2E tests covering the complete bounty creation flow and step validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->