### PR TITLE
fix(saved): add empty state matching bounty-empty visual treatment

### DIFF
--- a/app/saved/saved-client.tsx
+++ b/app/saved/saved-client.tsx
@@ -44,16 +44,16 @@ function SavedBountiesClient() {
 
   if (bookmarkedBounties.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="rounded-full bg-muted p-4 mb-4">
-          <Bookmark className="h-8 w-8 text-muted-foreground" />
+      <div className="flex flex-col items-center justify-center py-24 text-center border border-dashed border-gray-800 rounded-2xl bg-background-card/30">
+        <div className="size-16 rounded-full bg-gray-800/50 flex items-center justify-center mb-4">
+          <Bookmark className="size-8 text-gray-600" />
         </div>
-        <h2 className="text-xl font-semibold mb-2">No saved bounties yet</h2>
-        <p className="text-muted-foreground max-w-sm mb-6">
+        <h3 className="text-xl font-bold mb-2 text-gray-200">No saved bounties yet</h3>
+        <p className="text-gray-400 max-w-md mx-auto mb-6">
           Bookmark interesting bounties to save them here for later review.
         </p>
-        <Button asChild>
-          <Link href="/">Explore Bounties</Link>
+        <Button asChild variant="outline" className="border-gray-700 hover:bg-gray-800">
+          <Link href="/bounty">Browse bounties</Link>
         </Button>
       </div>
     );


### PR DESCRIPTION
Replace the unstyled empty state on /saved with a dashed-border card that matches BountyEmpty styling. Updates icon, text colors, and the CTA button to link to /bounty as "Browse bounties".

Closes #213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the empty-state display for saved bounties with updated layout and visual styling
  * Refreshed the action button appearance and updated navigation link text

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->