### PR TITLE
fix: add aria-labels to all icon-only buttons for screen reader acces…

### DIFF
--- a/components/bounty-detail/bounty-detail-sidebar-cta.tsx
+++ b/components/bounty-detail/bounty-detail-sidebar-cta.tsx
@@ -520,6 +520,7 @@ export function MobileCTA({ bounty, onCancelled }: MobileCTAProps) {
               variant="outline"
               size="lg"
               className="h-11 border-red-500/30 text-red-400 hover:bg-red-500/10 shrink-0"
+              aria-label="Cancel bounty"
               onClick={() => setCancelDialogOpen(true)}
             >
               <XCircle className="size-4" />
@@ -548,6 +549,7 @@ export function MobileCTA({ bounty, onCancelled }: MobileCTAProps) {
               variant="outline"
               size="lg"
               className="h-11 border-red-500/30 text-red-400 hover:bg-red-500/10 shrink-0"
+              aria-label="Cancel bounty"
               onClick={() => setCancelDialogOpen(true)}
             >
               <XCircle className="size-4" />

--- a/components/bounty-detail/model4-maintainer-dashboard.tsx
+++ b/components/bounty-detail/model4-maintainer-dashboard.tsx
@@ -135,6 +135,7 @@ export function Model4MaintainerDashboard({
                             variant="ghost"
                             size="icon-sm"
                             className="text-gray-400 hover:text-white"
+                            aria-label="Send message"
                             onClick={() =>
                               handleAction("Message", contributor.userName)
                             }
@@ -224,6 +225,7 @@ export function Model4MaintainerDashboard({
                             variant="ghost"
                             size="icon-sm"
                             className="text-red-400/50 hover:text-red-400 hover:bg-red-400/10"
+                            aria-label="Remove from slot"
                             onClick={() =>
                               handleAction("Remove", contributor.userName)
                             }

--- a/components/bounty/forms/milestone-builder.tsx
+++ b/components/bounty/forms/milestone-builder.tsx
@@ -113,6 +113,7 @@ export function MilestoneBuilder<
                 size="icon-sm"
                 onClick={() => remove(index)}
                 disabled={fields.length === 1}
+                aria-label="Remove milestone"
                 className="text-muted-foreground hover:text-destructive"
               >
                 <Trash2 className="size-4" />

--- a/components/compliance/document-upload.tsx
+++ b/components/compliance/document-upload.tsx
@@ -98,7 +98,7 @@ export function DocumentUpload({
             </div>
           </div>
           {!uploaded && !uploading && (
-            <Button variant="ghost" size="sm" onClick={clearFile}>
+            <Button variant="ghost" size="sm" onClick={clearFile} aria-label="Clear file">
               <X className="w-4 h-4" />
             </Button>
           )}

--- a/components/global-navbar.tsx
+++ b/components/global-navbar.tsx
@@ -136,7 +136,7 @@ export function GlobalNavbar() {
             <WalletSheet
               walletInfo={activeWalletInfo}
               trigger={
-                <Button variant="outline" size="icon">
+                <Button variant="outline" size="icon" aria-label="Open wallet">
                   <Wallet className="h-4 w-4" />
                 </Button>
               }

--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -18,10 +18,9 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" aria-label="Toggle theme">
           <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-          <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/components/wallet/wallet-sheet.tsx
+++ b/components/wallet/wallet-sheet.tsx
@@ -48,7 +48,7 @@ export function WalletSheet({ walletInfo, trigger }: WalletSheetProps) {
     <Sheet>
       <SheetTrigger asChild>
         {trigger || (
-          <Button variant="outline" size="icon">
+          <Button variant="outline" size="icon" aria-label="Open wallet">
             <Wallet className="h-4 w-4" />
           </Button>
         )}


### PR DESCRIPTION
Closes #216

---

…sibility

- mode-toggle.tsx: Replace sr-only span with aria-label
- model4-maintainer-dashboard.tsx: Add aria-labels to message and remove buttons
- wallet-sheet.tsx: Add aria-label to wallet icon button
- global-navbar.tsx: Add aria-label to wallet icon button
- document-upload.tsx: Add aria-label to clear file button
- milestone-builder.tsx: Add aria-label to remove milestone button
- bounty-detail-sidebar-cta.tsx: Add aria-labels to cancel bounty buttons

All icon-only buttons now announce properly to screen readers with meaningful, context-specific labels. Fixes accessibility failure where buttons rendered only icons with no visible text, announcing as 'button' with no context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added descriptive labels to icon buttons throughout the application, including wallet actions, theme toggle, and various action buttons, enhancing screen reader support and overall accessibility for users relying on assistive technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->