### PR TITLE
Add decline applicant review flow

### DIFF
--- a/components/bounty/application-review-dashboard.tsx
+++ b/components/bounty/application-review-dashboard.tsx
@@ -8,12 +8,28 @@ import {
   Star,
   Trophy,
   ArrowRight,
+  XCircle,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
 
-import { useSelectApplicant } from "@/hooks/use-bounty-application";
+import {
+  useDeclineApplicant,
+  useSelectApplicant,
+} from "@/hooks/use-bounty-application";
 
 export interface Application {
   id: string;
@@ -45,8 +61,13 @@ export function ApplicationReviewDashboard({
   applications,
 }: ApplicationReviewDashboardProps) {
   const [selectedForCompare, setSelectedForCompare] = useState<string[]>([]);
+  const [declineReason, setDeclineReason] = useState("");
+  const [applicationToDecline, setApplicationToDecline] =
+    useState<Application | null>(null);
   const { mutate: selectApplicant, isPending: isSelecting } =
     useSelectApplicant();
+  const { mutate: declineApplicant, isPending: isDeclining } =
+    useDeclineApplicant();
 
   const handleSelectApplicant = (applicantAddress: string) => {
     selectApplicant({
@@ -62,6 +83,45 @@ export function ApplicationReviewDashboard({
     } else if (selectedForCompare.length < 2) {
       setSelectedForCompare([...selectedForCompare, id]);
     }
+  };
+
+  const openDeclineDialog = (app: Application) => {
+    setApplicationToDecline(app);
+    setDeclineReason("");
+  };
+
+  const closeDeclineDialog = () => {
+    setApplicationToDecline(null);
+    setDeclineReason("");
+  };
+
+  const handleDeclineApplicant = () => {
+    if (!applicationToDecline) return;
+
+    const declinedApplication = applicationToDecline;
+    declineApplicant(
+      {
+        bountyId,
+        applicantAddress: declinedApplication.applicantAddress,
+        reason: declineReason,
+      },
+      {
+        onSuccess: () => {
+          setSelectedForCompare((current) =>
+            current.filter((id) => id !== declinedApplication.id),
+          );
+          toast.success("Application declined");
+          closeDeclineDialog();
+        },
+        onError: (error) => {
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Failed to decline application",
+          );
+        },
+      },
+    );
   };
 
   const renderApplicationCard = (app: Application, isCompact = false) => (
@@ -119,6 +179,15 @@ export function ApplicationReviewDashboard({
               disabled={isSelecting}
             >
               <CheckCircle className="size-4 mr-1" /> Select
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-red-500/40 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+              onClick={() => openDeclineDialog(app)}
+              disabled={isDeclining}
+            >
+              <XCircle className="size-4 mr-1" /> Decline
             </Button>
           </div>
         </div>
@@ -204,6 +273,42 @@ export function ApplicationReviewDashboard({
           {applications.map((app) => renderApplicationCard(app, false))}
         </div>
       )}
+
+      <AlertDialog
+        open={applicationToDecline !== null}
+        onOpenChange={(open) => {
+          if (!open) closeDeclineDialog();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Decline application</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the application from the review queue.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Textarea
+            value={declineReason}
+            onChange={(event) => setDeclineReason(event.target.value)}
+            placeholder="Optional reason"
+            disabled={isDeclining}
+            className="min-h-24"
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeclining}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                handleDeclineApplicant();
+              }}
+              disabled={isDeclining}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              Decline
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -19,6 +19,11 @@ type ApplicationContractClient = {
     bountyId: bigint;
     applicant: string;
   }) => Promise<{ txHash: string }>;
+  declineApplicant?: (params: {
+    bountyId: bigint;
+    applicant: string;
+    reason?: string;
+  }) => Promise<{ txHash: string }>;
   submitWork: (params: {
     contributor: string;
     bountyId: bigint;
@@ -147,6 +152,110 @@ export function useSelectApplicant() {
     onSettled: (_r, _e, v) => {
       qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
       qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+    },
+  });
+}
+
+type ApplicationCacheEntry = {
+  id: string;
+  applicantAddress: string;
+  status?: string;
+  declineReason?: string;
+};
+
+type BountyWithApplications = BountyQuery["bounty"] & {
+  applications?: ApplicationCacheEntry[];
+  declinedApplications?: ApplicationCacheEntry[];
+};
+
+type BountyQueryWithApplications = Omit<BountyQuery, "bounty"> & {
+  bounty: BountyWithApplications;
+};
+
+// ---------------------------------------------------------------------------
+// Hook: decline applicant
+// ---------------------------------------------------------------------------
+
+export function useDeclineApplicant() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      bountyId,
+      applicantAddress,
+      reason,
+    }: {
+      bountyId: string;
+      applicantAddress: string;
+      reason?: string;
+    }) => {
+      const client = (
+        globalThis as { __applicationContracts?: ApplicationContractClient }
+      ).__applicationContracts;
+
+      if (client?.declineApplicant) {
+        return {
+          persisted: true,
+          result: await client.declineApplicant({
+            bountyId: toBountyIdBigInt(bountyId),
+            applicant: applicantAddress,
+            reason,
+          }),
+        };
+      }
+
+      return {
+        persisted: false,
+        result: { txHash: "local-decline-applicant" },
+      };
+    },
+    onMutate: async ({ bountyId, applicantAddress, reason }) => {
+      await qc.cancelQueries({ queryKey: bountyKeys.detail(bountyId) });
+      const prev = qc.getQueryData<BountyQueryWithApplications>(
+        bountyKeys.detail(bountyId),
+      );
+
+      if (prev?.bounty?.applications) {
+        const declinedApplication = prev.bounty.applications.find(
+          (app) => app.applicantAddress === applicantAddress,
+        );
+        const declineReason = reason?.trim() || undefined;
+
+        qc.setQueryData<BountyQueryWithApplications>(
+          bountyKeys.detail(bountyId),
+          {
+            ...prev,
+            bounty: {
+              ...prev.bounty,
+              applications: prev.bounty.applications.filter(
+                (app) => app.applicantAddress !== applicantAddress,
+              ),
+              declinedApplications: declinedApplication
+                ? [
+                    ...(prev.bounty.declinedApplications ?? []),
+                    {
+                      ...declinedApplication,
+                      status: "declined",
+                      declineReason,
+                    },
+                  ]
+                : prev.bounty.declinedApplications,
+              updatedAt: new Date().toISOString(),
+            },
+          },
+        );
+      }
+
+      return { prev, bountyId };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(bountyKeys.detail(ctx.bountyId), ctx.prev);
+    },
+    onSuccess: (response, v) => {
+      if (response.persisted) {
+        qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
+        qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+      }
     },
   });
 }


### PR DESCRIPTION
Closes #208.

## Summary
- add a `useDeclineApplicant` mutation with optimistic removal and rollback
- preserve declined application details plus optional reason in the bounty detail cache
- add a red-outline Decline button, confirmation dialog, optional reason field, success/error toasts, and comparison cleanup

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint components/bounty/application-review-dashboard.tsx hooks/use-bounty-application.ts`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Applicants can now be declined directly from the application review dashboard
  * Each application card displays a "Decline" button for easy access
  * A confirmation dialog appears when declining, with an optional field to provide a decline reason
  * Success and error notifications confirm the outcome of the decline action

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->