### PR TITLE
fix: throw error when decline binding is unavailable

### DIFF
--- a/components/bounty/application-review-dashboard.tsx
+++ b/components/bounty/application-review-dashboard.tsx
@@ -8,12 +8,28 @@ import {
   Star,
   Trophy,
   ArrowRight,
+  XCircle,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
 
-import { useSelectApplicant } from "@/hooks/use-bounty-application";
+import {
+  useDeclineApplicant,
+  useSelectApplicant,
+} from "@/hooks/use-bounty-application";
 
 export interface Application {
   id: string;
@@ -45,8 +61,13 @@ export function ApplicationReviewDashboard({
   applications,
 }: ApplicationReviewDashboardProps) {
   const [selectedForCompare, setSelectedForCompare] = useState<string[]>([]);
+  const [declineReason, setDeclineReason] = useState("");
+  const [applicationToDecline, setApplicationToDecline] =
+    useState<Application | null>(null);
   const { mutate: selectApplicant, isPending: isSelecting } =
     useSelectApplicant();
+  const { mutate: declineApplicant, isPending: isDeclining } =
+    useDeclineApplicant();
 
   const handleSelectApplicant = (applicantAddress: string) => {
     selectApplicant({
@@ -62,6 +83,45 @@ export function ApplicationReviewDashboard({
     } else if (selectedForCompare.length < 2) {
       setSelectedForCompare([...selectedForCompare, id]);
     }
+  };
+
+  const openDeclineDialog = (app: Application) => {
+    setApplicationToDecline(app);
+    setDeclineReason("");
+  };
+
+  const closeDeclineDialog = () => {
+    setApplicationToDecline(null);
+    setDeclineReason("");
+  };
+
+  const handleDeclineApplicant = () => {
+    if (!applicationToDecline) return;
+
+    const declinedApplication = applicationToDecline;
+    declineApplicant(
+      {
+        bountyId,
+        applicantAddress: declinedApplication.applicantAddress,
+        reason: declineReason,
+      },
+      {
+        onSuccess: () => {
+          setSelectedForCompare((current) =>
+            current.filter((id) => id !== declinedApplication.id),
+          );
+          toast.success("Application declined");
+          closeDeclineDialog();
+        },
+        onError: (error) => {
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Failed to decline application",
+          );
+        },
+      },
+    );
   };
 
   const renderApplicationCard = (app: Application, isCompact = false) => (
@@ -119,6 +179,15 @@ export function ApplicationReviewDashboard({
               disabled={isSelecting}
             >
               <CheckCircle className="size-4 mr-1" /> Select
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-red-500/40 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+              onClick={() => openDeclineDialog(app)}
+              disabled={isDeclining}
+            >
+              <XCircle className="size-4 mr-1" /> Decline
             </Button>
           </div>
         </div>
@@ -204,6 +273,42 @@ export function ApplicationReviewDashboard({
           {applications.map((app) => renderApplicationCard(app, false))}
         </div>
       )}
+
+      <AlertDialog
+        open={applicationToDecline !== null}
+        onOpenChange={(open) => {
+          if (!open) closeDeclineDialog();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Decline application</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the application from the review queue.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Textarea
+            value={declineReason}
+            onChange={(event) => setDeclineReason(event.target.value)}
+            placeholder="Optional reason"
+            disabled={isDeclining}
+            className="min-h-24"
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeclining}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                handleDeclineApplicant();
+              }}
+              disabled={isDeclining}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              Decline
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -204,10 +204,9 @@ export function useDeclineApplicant() {
         };
       }
 
-      return {
-        persisted: false,
-        result: { txHash: "local-decline-applicant" },
-      };
+      throw new Error(
+        "Decline is not available for this bounty. Please check the application contract.",
+      );
     },
     onMutate: async ({ bountyId, applicantAddress, reason }) => {
       await qc.cancelQueries({ queryKey: bountyKeys.detail(bountyId) });

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -19,6 +19,11 @@ type ApplicationContractClient = {
     bountyId: bigint;
     applicant: string;
   }) => Promise<{ txHash: string }>;
+  declineApplicant?: (params: {
+    bountyId: bigint;
+    applicant: string;
+    reason?: string;
+  }) => Promise<{ txHash: string }>;
   submitWork: (params: {
     contributor: string;
     bountyId: bigint;
@@ -147,6 +152,110 @@ export function useSelectApplicant() {
     onSettled: (_r, _e, v) => {
       qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
       qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+    },
+  });
+}
+
+type ApplicationCacheEntry = {
+  id: string;
+  applicantAddress: string;
+  status?: string;
+  declineReason?: string;
+};
+
+type BountyWithApplications = BountyQuery["bounty"] & {
+  applications?: ApplicationCacheEntry[];
+  declinedApplications?: ApplicationCacheEntry[];
+};
+
+type BountyQueryWithApplications = Omit<BountyQuery, "bounty"> & {
+  bounty: BountyWithApplications;
+};
+
+// ---------------------------------------------------------------------------
+// Hook: decline applicant
+// ---------------------------------------------------------------------------
+
+export function useDeclineApplicant() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      bountyId,
+      applicantAddress,
+      reason,
+    }: {
+      bountyId: string;
+      applicantAddress: string;
+      reason?: string;
+    }) => {
+      const client = (
+        globalThis as { __applicationContracts?: ApplicationContractClient }
+      ).__applicationContracts;
+
+      if (client?.declineApplicant) {
+        return {
+          persisted: true,
+          result: await client.declineApplicant({
+            bountyId: toBountyIdBigInt(bountyId),
+            applicant: applicantAddress,
+            reason,
+          }),
+        };
+      }
+
+      return {
+        persisted: false,
+        result: { txHash: "local-decline-applicant" },
+      };
+    },
+    onMutate: async ({ bountyId, applicantAddress, reason }) => {
+      await qc.cancelQueries({ queryKey: bountyKeys.detail(bountyId) });
+      const prev = qc.getQueryData<BountyQueryWithApplications>(
+        bountyKeys.detail(bountyId),
+      );
+
+      if (prev?.bounty?.applications) {
+        const declinedApplication = prev.bounty.applications.find(
+          (app) => app.applicantAddress === applicantAddress,
+        );
+        const declineReason = reason?.trim() || undefined;
+
+        qc.setQueryData<BountyQueryWithApplications>(
+          bountyKeys.detail(bountyId),
+          {
+            ...prev,
+            bounty: {
+              ...prev.bounty,
+              applications: prev.bounty.applications.filter(
+                (app) => app.applicantAddress !== applicantAddress,
+              ),
+              declinedApplications: declinedApplication
+                ? [
+                    ...(prev.bounty.declinedApplications ?? []),
+                    {
+                      ...declinedApplication,
+                      status: "declined",
+                      declineReason,
+                    },
+                  ]
+                : prev.bounty.declinedApplications,
+              updatedAt: new Date().toISOString(),
+            },
+          },
+        );
+      }
+
+      return { prev, bountyId };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(bountyKeys.detail(ctx.bountyId), ctx.prev);
+    },
+    onSuccess: (response, v) => {
+      if (response.persisted) {
+        qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
+        qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+      }
     },
   });
 }

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -189,24 +189,22 @@ export function useDeclineApplicant() {
       applicantAddress: string;
       reason?: string;
     }) => {
-      const client = (
-        globalThis as { __applicationContracts?: ApplicationContractClient }
-      ).__applicationContracts;
-
-      if (client?.declineApplicant) {
-        return {
-          persisted: true,
-          result: await client.declineApplicant({
-            bountyId: toBountyIdBigInt(bountyId),
-            applicant: applicantAddress,
-            reason,
-          }),
-        };
+      const client = resolveApplicationClient();
+      if (!client.declineApplicant) {
+        throw new ApplicationError(
+          "missing_contract_bindings",
+          "Decline is not available for this bounty. Please check the application contract.",
+        );
       }
 
-      throw new Error(
-        "Decline is not available for this bounty. Please check the application contract.",
-      );
+      return {
+        persisted: true,
+        result: await client.declineApplicant({
+          bountyId: toBountyIdBigInt(bountyId),
+          applicant: applicantAddress,
+          reason,
+        }),
+      };
     },
     onMutate: async ({ bountyId, applicantAddress, reason }) => {
       await qc.cancelQueries({ queryKey: bountyKeys.detail(bountyId) });


### PR DESCRIPTION
## What

The `useDeclineApplicant` hook returns a fake success result when the contract client does not include `declineApplicant`. This leaves the optimistic cache removal in place and shows a misleading success toast.

## Why

Line 207 returns `{ persisted: false, result: { txHash: "local-decline-applicant" } }` instead of throwing. Since the mutation "succeeds", `onError` never fires and the optimistic update is never rolled back.

## How

Replace the fake return with `throw new ApplicationError(...)` so the error boundary rolls back the cache and the user sees an actual error message.

## Checklist

- [x] No new dependencies
- [x] Existing error handling (`onError` + `onMutate` rollback) handles this correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications can now be declined directly from the review dashboard with an optional decline reason
  * A confirmation dialog allows you to add context before declining an application
  * Declined applications are automatically moved to a separate section
  * Real-time notifications confirm successful or failed decline operations
  * The decline button is disabled during processing to prevent duplicate submissions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->