### PR TITLE
Add aria labels to icon-only buttons

### DIFF
--- a/components/bounty-detail/bounty-detail-sidebar-cta.tsx
+++ b/components/bounty-detail/bounty-detail-sidebar-cta.tsx
@@ -314,6 +314,8 @@ export function SidebarCTA({ bounty, onCancelled }: SidebarCTAProps) {
 
         {/* Copy link */}
         <button
+          type="button"
+          aria-label="Copy link"
           onClick={handleCopy}
           className="w-full flex items-center justify-center gap-1.5 text-xs text-gray-500 hover:text-gray-300 transition-colors py-1"
         >

--- a/components/bounty-detail/model4-maintainer-dashboard.tsx
+++ b/components/bounty-detail/model4-maintainer-dashboard.tsx
@@ -134,6 +134,7 @@ export function Model4MaintainerDashboard({
                           <Button
                             variant="ghost"
                             size="icon-sm"
+                            aria-label={`Send message to ${contributor.userName}`}
                             className="text-gray-400 hover:text-white"
                             onClick={() =>
                               handleAction("Message", contributor.userName)
@@ -223,6 +224,7 @@ export function Model4MaintainerDashboard({
                           <Button
                             variant="ghost"
                             size="icon-sm"
+                            aria-label={`Remove ${contributor.userName} from slot`}
                             className="text-red-400/50 hover:text-red-400 hover:bg-red-400/10"
                             onClick={() =>
                               handleAction("Remove", contributor.userName)

--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -18,7 +18,7 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" aria-label="Toggle theme">
           <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
           <span className="sr-only">Toggle theme</span>


### PR DESCRIPTION
## Summary
- add `aria-label` to the theme toggle icon button
- add `aria-label` and explicit `type=button` to the copy-link icon action
- add contextual `aria-label`s to icon-only maintainer actions

Closes #216

## Testing
- `git diff --check` ✅
- `npm run lint` ⚠️ blocked locally: dependency install/runtime missing module `./UTF16SurrogatePairToCodePoint` after `npm ci`
- `jest --runInBand --passWithNoTests` ⚠️ blocked locally: dependency/runtime issue; earlier `next/jest` missing before clean install


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for screen readers and assistive technologies by adding missing semantic labels to interactive buttons across the app, including the copy link button, message actions, and theme toggle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->