### PR TITLE
chore(skeleton): use border-border token instead of hardcoded color

### DIFF
--- a/components/ui/loading/bounty-card-skeleton.tsx
+++ b/components/ui/loading/bounty-card-skeleton.tsx
@@ -22,7 +22,7 @@ export function BountyCardSkeleton() {
           <Skeleton className="h-6 w-20 rounded-full" />
         </div>
       </CardHeader>
-      <CardFooter className="border-t border-[#f0f0f0] dark:border-slate-700 py-3 px-5">
+      <CardFooter className="border-t border-border py-3 px-5">
         <div className="flex items-center gap-2 w-full justify-between">
           <div className="flex items-center gap-2">
             <Skeleton className="h-5 w-5 rounded-full" />


### PR DESCRIPTION
Replaces `border-[#f0f0f0] dark:border-slate-700` with the standard `border-border` token in `BountyCardSkeleton`. Pre-existing from the old skeleton file, carried over during #236.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated bounty card loading skeleton styling to use consistent theme-based colors, improving visual coherence across light and dark modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->