### PR TITLE
feat: add decline applicant flow

### DIFF
--- a/components/bounty/application-review-dashboard.tsx
+++ b/components/bounty/application-review-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Users,
   CheckCircle,
@@ -8,12 +8,27 @@ import {
   Star,
   Trophy,
   ArrowRight,
+  XCircle,
 } from "lucide-react";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
 
-import { useSelectApplicant } from "@/hooks/use-bounty-application";
+import {
+  useDeclineApplicant,
+  useSelectApplicant,
+} from "@/hooks/use-bounty-application";
 
 export interface Application {
   id: string;
@@ -45,8 +60,20 @@ export function ApplicationReviewDashboard({
   applications,
 }: ApplicationReviewDashboardProps) {
   const [selectedForCompare, setSelectedForCompare] = useState<string[]>([]);
+  const [visibleApplications, setVisibleApplications] = useState(applications);
+  const [declineTarget, setDeclineTarget] = useState<{
+    application: Application;
+    index: number;
+  } | null>(null);
+  const [declineReason, setDeclineReason] = useState("");
   const { mutate: selectApplicant, isPending: isSelecting } =
     useSelectApplicant();
+  const { mutate: declineApplicant, isPending: isDeclining } =
+    useDeclineApplicant();
+
+  useEffect(() => {
+    setVisibleApplications(applications);
+  }, [applications]);
 
   const handleSelectApplicant = (applicantAddress: string) => {
     selectApplicant({
@@ -62,6 +89,58 @@ export function ApplicationReviewDashboard({
     } else if (selectedForCompare.length < 2) {
       setSelectedForCompare([...selectedForCompare, id]);
     }
+  };
+
+  const handleDeclineApplicant = () => {
+    if (!declineTarget) return;
+
+    const { application, index } = declineTarget;
+    const reason = declineReason.trim();
+    const wasSelectedForCompare = selectedForCompare.includes(application.id);
+
+    setVisibleApplications((current) =>
+      current.filter((item) => item.id !== application.id),
+    );
+    setSelectedForCompare((current) =>
+      current.filter((id) => id !== application.id),
+    );
+    setDeclineTarget(null);
+    setDeclineReason("");
+
+    declineApplicant(
+      {
+        bountyId,
+        applicantAddress: application.applicantAddress,
+        reason,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Application declined.");
+        },
+        onError: (error) => {
+          setVisibleApplications((current) => {
+            if (current.some((item) => item.id === application.id)) {
+              return current;
+            }
+            const next = [...current];
+            next.splice(Math.max(index, 0), 0, application);
+            return next;
+          });
+          if (wasSelectedForCompare) {
+            setSelectedForCompare((current) =>
+              current.includes(application.id) || current.length >= 2
+                ? current
+                : [...current, application.id],
+            );
+          }
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Failed to decline application.",
+          );
+        },
+      },
+    );
   };
 
   const renderApplicationCard = (app: Application, isCompact = false) => (
@@ -116,9 +195,25 @@ export function ApplicationReviewDashboard({
             <Button
               size="sm"
               onClick={() => handleSelectApplicant(app.applicantAddress)}
-              disabled={isSelecting}
+              disabled={isSelecting || isDeclining}
             >
               <CheckCircle className="size-4 mr-1" /> Select
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-red-500/40 text-red-400 hover:bg-red-500/10 hover:text-red-300"
+              onClick={() =>
+                setDeclineTarget({
+                  application: app,
+                  index: visibleApplications.findIndex(
+                    (item) => item.id === app.id,
+                  ),
+                })
+              }
+              disabled={isSelecting || isDeclining}
+            >
+              <XCircle className="size-4 mr-1" /> Decline
             </Button>
           </div>
         </div>
@@ -159,7 +254,7 @@ export function ApplicationReviewDashboard({
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-bold flex items-center gap-2">
           <Users className="size-5 text-primary" />
-          Review Applications ({applications.length})
+          Review Applications ({visibleApplications.length})
         </h2>
         {selectedForCompare.length > 0 && (
           <Badge variant="outline" className="text-sm">
@@ -168,7 +263,7 @@ export function ApplicationReviewDashboard({
         )}
       </div>
 
-      {applications.length === 0 ? (
+      {visibleApplications.length === 0 ? (
         <Card className="border-dashed border-gray-800 bg-transparent">
           <CardContent className="flex flex-col items-center justify-center py-12 text-center">
             <Users className="size-12 text-gray-600 mb-4" />
@@ -194,16 +289,52 @@ export function ApplicationReviewDashboard({
             </Button>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {applications
+            {visibleApplications
               .filter((app) => selectedForCompare.includes(app.id))
               .map((app) => renderApplicationCard(app, false))}
           </div>
         </div>
       ) : (
         <div className="grid gap-4">
-          {applications.map((app) => renderApplicationCard(app, false))}
+          {visibleApplications.map((app) => renderApplicationCard(app, false))}
         </div>
       )}
+
+      <AlertDialog
+        open={declineTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeclineTarget(null);
+            setDeclineReason("");
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Decline this application?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the applicant from the review queue. You can include
+              a short reason for the applicant notification cache.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Textarea
+            value={declineReason}
+            onChange={(event) => setDeclineReason(event.target.value)}
+            placeholder="Optional reason"
+            rows={4}
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeclining}>Cancel</AlertDialogCancel>
+            <Button
+              className="bg-red-600 text-white hover:bg-red-700"
+              onClick={handleDeclineApplicant}
+              disabled={isDeclining}
+            >
+              Decline applicant
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -29,7 +29,35 @@ type ApplicationContractClient = {
     bountyId: bigint;
     points: number;
   }) => Promise<{ txHash: string }>;
+  declineApplicant?: (params: {
+    bountyId: bigint;
+    applicant: string;
+    reason?: string;
+  }) => Promise<{ txHash?: string }>;
 };
+
+type CachedApplication = {
+  applicantAddress?: string;
+  status?: string;
+  declinedReason?: string;
+  declinedAt?: string;
+};
+
+type BountyQueryWithApplications = BountyQuery & {
+  bounty?: BountyQuery["bounty"] & {
+    applications?: CachedApplication[];
+  };
+};
+
+type DeclinedApplicationRecord = {
+  bountyId: string;
+  applicantAddress: string;
+  reason?: string;
+  declinedAt: string;
+};
+
+const declinedApplicationsKey = (bountyId: string) =>
+  ["bounty", bountyId, "declined-applications"] as const;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -143,6 +171,104 @@ export function useSelectApplicant() {
     },
     onError: (_e, _v, ctx) => {
       if (ctx?.prev) qc.setQueryData(bountyKeys.detail(ctx.bountyId), ctx.prev);
+    },
+    onSettled: (_r, _e, v) => {
+      qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
+      qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hook: decline applicant
+// ---------------------------------------------------------------------------
+
+export function useDeclineApplicant() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      bountyId,
+      applicantAddress,
+      reason,
+    }: {
+      bountyId: string;
+      applicantAddress: string;
+      reason?: string;
+    }) => {
+      const client = (
+        globalThis as { __applicationContracts?: ApplicationContractClient }
+      ).__applicationContracts;
+      const trimmedReason = reason?.trim() || undefined;
+
+      if (client?.declineApplicant) {
+        return client.declineApplicant({
+          bountyId: toBountyIdBigInt(bountyId),
+          applicant: applicantAddress,
+          reason: trimmedReason,
+        });
+      }
+
+      return {
+        applicantAddress,
+        bountyId,
+        reason: trimmedReason,
+      };
+    },
+    onMutate: async ({ bountyId, applicantAddress, reason }) => {
+      const detailKey = bountyKeys.detail(bountyId);
+      const declinedKey = declinedApplicationsKey(bountyId);
+      await qc.cancelQueries({ queryKey: detailKey });
+
+      const prevDetail =
+        qc.getQueryData<BountyQueryWithApplications>(detailKey);
+      const prevDeclined =
+        qc.getQueryData<DeclinedApplicationRecord[]>(declinedKey) ?? [];
+      const declinedAt = new Date().toISOString();
+      const trimmedReason = reason?.trim() || undefined;
+
+      qc.setQueryData<DeclinedApplicationRecord[]>(declinedKey, [
+        ...prevDeclined.filter(
+          (item) => item.applicantAddress !== applicantAddress,
+        ),
+        {
+          bountyId,
+          applicantAddress,
+          reason: trimmedReason,
+          declinedAt,
+        },
+      ]);
+
+      if (prevDetail?.bounty?.applications) {
+        qc.setQueryData<BountyQueryWithApplications>(detailKey, {
+          ...prevDetail,
+          bounty: {
+            ...prevDetail.bounty,
+            applications: prevDetail.bounty.applications
+              .map((application) =>
+                application.applicantAddress === applicantAddress
+                  ? {
+                      ...application,
+                      status: "DECLINED",
+                      declinedReason: trimmedReason,
+                      declinedAt,
+                    }
+                  : application,
+              )
+              .filter(
+                (application) =>
+                  application.applicantAddress !== applicantAddress,
+              ),
+          },
+        });
+      }
+
+      return { bountyId, detailKey, declinedKey, prevDetail, prevDeclined };
+    },
+    onError: (_e, _v, ctx) => {
+      if (!ctx) return;
+      qc.setQueryData(ctx.detailKey, ctx.prevDetail);
+      qc.setQueryData(ctx.declinedKey, ctx.prevDeclined);
     },
     onSettled: (_r, _e, v) => {
       qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });


### PR DESCRIPTION
## Summary
- add `useDeclineApplicant` with optimistic cache updates and rollback
- add a red-outline Decline action next to Select on application cards
- add a confirmation dialog with optional reason text, success/error toast handling, and comparison-mode cleanup

Resolves #208

## Validation
- `./node_modules/.bin/eslint hooks/use-bounty-application.ts components/bounty/application-review-dashboard.tsx`
- `git diff --check`

## Notes
- Full `tsc --noEmit` currently stops on an existing repository test type issue: `components/reputation/__tests__/my-claims.test.ts` cannot resolve `@jest/globals`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now decline applications directly from the review dashboard with optional decline reasons
  * Added error handling and recovery for decline operations with user feedback notifications
  * Decline and select buttons disable during pending operations to prevent duplicate actions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->