### PR TITLE
feat: implement decline applicant flow on application review dashboard

### DIFF
--- a/components/bounty/application-review-dashboard.tsx
+++ b/components/bounty/application-review-dashboard.tsx
@@ -8,12 +8,26 @@ import {
   Star,
   Trophy,
   ArrowRight,
+  XCircle,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
-import { useSelectApplicant } from "@/hooks/use-bounty-application";
+import {
+  useSelectApplicant,
+  useDeclineApplicant,
+} from "@/hooks/use-bounty-application";
 
 export interface Application {
   id: string;
@@ -45,8 +59,11 @@ export function ApplicationReviewDashboard({
   applications,
 }: ApplicationReviewDashboardProps) {
   const [selectedForCompare, setSelectedForCompare] = useState<string[]>([]);
+  const [declineTarget, setDeclineTarget] = useState<Application | null>(null);
   const { mutate: selectApplicant, isPending: isSelecting } =
     useSelectApplicant();
+  const { mutate: declineApplicant, isPending: isDeclining } =
+    useDeclineApplicant();
 
   const handleSelectApplicant = (applicantAddress: string) => {
     selectApplicant({
@@ -54,6 +71,20 @@ export function ApplicationReviewDashboard({
       creatorAddress,
       applicantAddress,
     });
+  };
+
+  const handleDeclineApplicant = () => {
+    if (!declineTarget) return;
+    declineApplicant(
+      {
+        bountyId,
+        creatorAddress,
+        applicantAddress: declineTarget.applicantAddress,
+      },
+      {
+        onSettled: () => setDeclineTarget(null),
+      },
+    );
   };
 
   const toggleCompare = (id: string) => {
@@ -113,6 +144,15 @@ export function ApplicationReviewDashboard({
                 {selectedForCompare.includes(app.id) ? "Comparing" : "Compare"}
               </Button>
             )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-red-400 border-red-400/30 hover:bg-red-400/10 hover:text-red-300"
+              onClick={() => setDeclineTarget(app)}
+              disabled={isDeclining}
+            >
+              <XCircle className="size-4 mr-1" /> Decline
+            </Button>
             <Button
               size="sm"
               onClick={() => handleSelectApplicant(app.applicantAddress)}
@@ -204,6 +244,37 @@ export function ApplicationReviewDashboard({
           {applications.map((app) => renderApplicationCard(app, false))}
         </div>
       )}
+
+      {/* Decline Confirmation Dialog */}
+      <AlertDialog
+        open={!!declineTarget}
+        onOpenChange={(open) => !open && setDeclineTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Decline Applicant</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to decline{" "}
+              <span className="font-semibold text-foreground">
+                {declineTarget?.applicantName ||
+                  `${declineTarget?.applicantAddress.slice(0, 8)}...`}
+              </span>
+              ? They will be notified and removed from the review queue. This
+              action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeclining}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeclineApplicant}
+              disabled={isDeclining}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              {isDeclining ? "Declining..." : "Decline Applicant"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -19,6 +19,11 @@ type ApplicationContractClient = {
     bountyId: bigint;
     applicant: string;
   }) => Promise<{ txHash: string }>;
+  declineApplicant: (params: {
+    creator: string;
+    bountyId: bigint;
+    applicant: string;
+  }) => Promise<{ txHash: string }>;
   submitWork: (params: {
     contributor: string;
     bountyId: bigint;
@@ -142,6 +147,59 @@ export function useSelectApplicant() {
       return { prev, bountyId };
     },
     onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(bountyKeys.detail(ctx.bountyId), ctx.prev);
+    },
+    onSettled: (_r, _e, v) => {
+      qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
+      qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hook: decline applicant (BountyRegistry.decline_applicant)
+// ---------------------------------------------------------------------------
+
+export function useDeclineApplicant() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      bountyId,
+      creatorAddress,
+      applicantAddress,
+    }: {
+      bountyId: string;
+      creatorAddress: string;
+      applicantAddress: string;
+    }) => {
+      const client = resolveApplicationClient();
+      return client.declineApplicant({
+        creator: creatorAddress,
+        bountyId: toBountyIdBigInt(bountyId),
+        applicant: applicantAddress,
+      });
+    },
+    onMutate: async ({ bountyId, applicantAddress }) => {
+      await qc.cancelQueries({ queryKey: bountyKeys.detail(bountyId) });
+      const prev = qc.getQueryData<BountyQuery>(bountyKeys.detail(bountyId));
+      // Optimistically remove the declined applicant from the cache
+      if (prev?.bounty?.applications) {
+        qc.setQueryData<BountyQuery>(bountyKeys.detail(bountyId), {
+          ...prev,
+          bounty: {
+            ...prev.bounty,
+            applications: prev.bounty.applications.filter(
+              (app: { applicantAddress: string }) =>
+                app.applicantAddress !== applicantAddress,
+            ),
+          },
+        });
+      }
+      return { prev, bountyId };
+    },
+    onError: (_e, _v, ctx) => {
+      // Rollback on error
       if (ctx?.prev) qc.setQueryData(bountyKeys.detail(ctx.bountyId), ctx.prev);
     },
     onSettled: (_r, _e, v) => {


### PR DESCRIPTION
## Summary

Implements the Decline applicant flow on the application review dashboard, allowing bounty creators to formally decline applicants with a notification and removal from the review queue.

### Changes

**`hooks/use-bounty-application.ts`:**
- Added `declineApplicant` to `ApplicationContractClient` type
- Added `useDeclineApplicant` mutation hook with:
  - Optimistic update: removes declined applicant from cache immediately
  - Rollback on error: restores previous state if transaction fails
  - Query invalidation on settlement

**`components/bounty/application-review-dashboard.tsx`:**
- Added Decline button with red-outline styling (matching previous version)
- Added AlertDialog confirmation before decline action
- Dialog warns that the action cannot be undone
- Shows applicant name or truncated address
- Loading state while decline is processing

### UI Flow

1. Creator sees application cards with Select, Compare, and Decline buttons
2. Clicking Decline opens a confirmation dialog
3. Confirming triggers the `declineApplicant` mutation
4. Applicant is optimistically removed from the list
5. On error, the applicant is restored to the list

Closes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to decline bounty applicants from the application review dashboard
  * Each applicant card now displays a new Decline button
  * A confirmation dialog appears when attempting to decline, showing applicant details and requiring explicit confirmation
  * The decline action is disabled during processing to prevent duplicate requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->