### PR TITLE
fix(apply-for-slot): lint and import cleanup from PR #251

### DIFF
--- a/e2e/bounty-application.spec.ts
+++ b/e2e/bounty-application.spec.ts
@@ -61,7 +61,7 @@ const MOCK_MULTI_WINNER_BOUNTY_FRAGMENT = {
       title: "Milestone 1: Design",
       description: "Design the UI/UX for the feature.",
       isCompleted: false,
-    }
+    },
   ],
   contributorProgress: [],
   maxSlots: 5,
@@ -136,11 +136,13 @@ async function setupMocks(page: Page) {
     } as ContestContracts;
 
     (globalThis as { __applyForSlotCalls?: number }).__applyForSlotCalls = 0;
-    (globalThis as { __applicationContracts?: unknown }).__applicationContracts = {
+    (
+      globalThis as { __applicationContracts?: unknown }
+    ).__applicationContracts = {
       applyForSlot: async () => {
         (globalThis as { __applyForSlotCalls?: number }).__applyForSlotCalls =
-          ((globalThis as { __applyForSlotCalls?: number }).__applyForSlotCalls ??
-            0) + 1;
+          ((globalThis as { __applyForSlotCalls?: number })
+            .__applyForSlotCalls ?? 0) + 1;
         return { txHash: "0xfake-e2e-slot-txhash" };
       },
     };
@@ -169,10 +171,14 @@ async function setupMocks(page: Page) {
   });
 
   await page.route("**/api/graphql", async (route) => {
-    let body: { operationName?: string } = {};
+    let body: {
+      operationName?: string;
+      variables?: { id?: string };
+    } = {};
     try {
       body = JSON.parse(route.request().postData() ?? "{}") as {
         operationName?: string;
+        variables?: { id?: string };
       };
     } catch {
       /* ignore */
@@ -186,7 +192,10 @@ async function setupMocks(page: Page) {
           body: JSON.stringify({
             data: {
               bounties: {
-                bounties: [MOCK_BOUNTY_FRAGMENT, MOCK_MULTI_WINNER_BOUNTY_FRAGMENT],
+                bounties: [
+                  MOCK_BOUNTY_FRAGMENT,
+                  MOCK_MULTI_WINNER_BOUNTY_FRAGMENT,
+                ],
                 total: 2,
                 limit: 20,
                 offset: 0,
@@ -195,11 +204,12 @@ async function setupMocks(page: Page) {
           }),
         });
         return;
-      case "Bounty":
-        const requestedId = (body as any).variables?.id;
-        const bountyData = requestedId === BOUNTY_ID_MULTI
-          ? MOCK_MULTI_WINNER_BOUNTY_FRAGMENT
-          : MOCK_BOUNTY_FRAGMENT;
+      case "Bounty": {
+        const requestedId = body.variables?.id;
+        const bountyData =
+          requestedId === BOUNTY_ID_MULTI
+            ? MOCK_MULTI_WINNER_BOUNTY_FRAGMENT
+            : MOCK_BOUNTY_FRAGMENT;
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -208,6 +218,7 @@ async function setupMocks(page: Page) {
           }),
         });
         return;
+      }
       case "TopContributors":
         await route.fulfill({
           status: 200,
@@ -389,7 +400,9 @@ test.describe("Bounty application flow", () => {
       await expect(btn).toBeEnabled();
     });
 
-    test("clicking Apply for Slot calls contract and updates UI", async ({ page }) => {
+    test("clicking Apply for Slot calls contract and updates UI", async ({
+      page,
+    }) => {
       await page.goto(`/bounty/${BOUNTY_ID_MULTI}`);
       const btn = page.getByRole("button", { name: "Apply for Slot" }).first();
       await expect(btn).toBeEnabled();
@@ -409,14 +422,18 @@ test.describe("Bounty application flow", () => {
         .toBeGreaterThan(0);
     });
 
-    test("shows Slots Full and disables when slot count is at capacity", async ({ page }) => {
+    test("shows Slots Full and disables when slot count is at capacity", async ({
+      page,
+    }) => {
       await page.route("**/api/graphql", async (route) => {
         let body: { operationName?: string } = {};
         try {
           body = JSON.parse(route.request().postData() ?? "{}") as {
             operationName?: string;
           };
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
         if (body.operationName === "Bounty") {
           await route.fulfill({
             status: 200,
@@ -443,14 +460,18 @@ test.describe("Bounty application flow", () => {
       await expect(btn).toBeDisabled();
     });
 
-    test("shows Already Joined and disables when user is in contributorProgress", async ({ page }) => {
+    test("shows Already Joined and disables when user is in contributorProgress", async ({
+      page,
+    }) => {
       await page.route("**/api/graphql", async (route) => {
         let body: { operationName?: string } = {};
         try {
           body = JSON.parse(route.request().postData() ?? "{}") as {
             operationName?: string;
           };
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
         if (body.operationName === "Bounty") {
           await route.fulfill({
             status: 200,

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -1,8 +1,11 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { authClient } from "@/lib/auth-client";
 import { bountyKeys } from "@/lib/query/query-keys";
+import { MOCK_MODEL4_MILESTONES } from "@/lib/mock/model4";
 import type { BountyQuery } from "@/lib/graphql/generated";
+import type { ContributorProgress, Bounty } from "@/types/bounty";
 
 // ---------------------------------------------------------------------------
 // Contract client shape (resolved from globalThis.__applicationContracts)
@@ -257,10 +260,6 @@ export function useApproveApplicationSubmission() {
 // Hook: apply for slot (BountyRegistry.apply_for_slot)
 // ---------------------------------------------------------------------------
 
-import { authClient } from "@/lib/auth-client";
-import { MOCK_MODEL4_MILESTONES } from "@/lib/mock/model4";
-import type { ContributorProgress, Bounty } from "@/types/bounty";
-
 export function useApplyForSlot() {
   const qc = useQueryClient();
   const { data: session } = authClient.useSession();
@@ -290,21 +289,25 @@ export function useApplyForSlot() {
         const newProgress: ContributorProgress = {
           userId: session?.user?.id ?? "unknown-user",
           userName: session?.user?.name ?? "Contributor",
-          userAvatarUrl: session?.user?.image ?? "https://github.com/shadcn.png",
+          userAvatarUrl:
+            session?.user?.image ?? "https://github.com/shadcn.png",
           currentMilestoneId: firstMilestoneId,
         };
         const prevProgress = prev.bounty.contributorProgress ?? [];
         const updatedProgress = [...prevProgress, newProgress];
         const occupied = (prev.bounty.totalSlotsOccupied ?? 0) + 1;
 
-        qc.setQueryData<BountyQuery & { bounty?: Partial<Bounty> }>(bountyKeys.detail(bountyId), {
-          ...prev,
-          bounty: {
-            ...prev.bounty,
-            totalSlotsOccupied: occupied,
-            contributorProgress: updatedProgress,
+        qc.setQueryData<BountyQuery & { bounty?: Partial<Bounty> }>(
+          bountyKeys.detail(bountyId),
+          {
+            ...prev,
+            bounty: {
+              ...prev.bounty,
+              totalSlotsOccupied: occupied,
+              contributorProgress: updatedProgress,
+            },
           },
-        });
+        );
       }
       return { prev, bountyId };
     },
@@ -313,7 +316,9 @@ export function useApplyForSlot() {
     },
     onSettled: (_r, _e, variables) => {
       if (variables?.bountyId) {
-        qc.invalidateQueries({ queryKey: bountyKeys.detail(variables.bountyId) });
+        qc.invalidateQueries({
+          queryKey: bountyKeys.detail(variables.bountyId),
+        });
       }
       qc.invalidateQueries({ queryKey: bountyKeys.lists() });
     },


### PR DESCRIPTION
PR #251 merged with a lint error and mid-file imports. Cleaning up.

## Changes

* `e2e/bounty-application.spec.ts:199` was using `(body as any).variables?.id`. Extended the typed `body` shape with `variables?: { id?: string }` so the cast goes away. Wrapped the `case "Bounty":` block in braces to scope the new `requestedId` / `bountyData` constants properly.
* `hooks/use-bounty-application.ts` had imports for `authClient`, `MOCK_MODEL4_MILESTONES`, `ContributorProgress`, and `Bounty` declared mid-file (line 260+) instead of at the top. Moved them up alongside the rest.

## Verified

* `pnpm lint` clean (only the pre-existing `server-graphql.ts` warning remains)
* `pnpm tsc --noEmit` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E test suite formatting and structure for improved readability.

* **Refactor**
  * Reorganized imports and reformatted code structure in application hooks for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->