### PR TITLE
chore: Remove ad-hoc bounty casts and extend Bounty type

### DIFF
--- a/components/bounty-detail/bounty-detail-client.tsx
+++ b/components/bounty-detail/bounty-detail-client.tsx
@@ -72,10 +72,7 @@ function getFullMilestoneData(bounty: BountyData): {
 // Backend does not currently provide applications in the response.
 // Fall back to empty array until the schema supports it.
 const getApplications = (bounty: BountyData): Application[] => {
-  return (
-    (bounty as BountyData & { applications?: Application[] })?.applications ??
-    []
-  );
+  return (bounty?.applications as unknown as Application[]) ?? [];
 };
 
 export function BountyDetailClient({ bountyId }: { bountyId: string }) {
@@ -156,8 +153,7 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
   // Identify if the current user is the assigned contributor
   // using a fallback check on submissions or assumed backend field.
   const isAssignedApplicant =
-    (bounty as BountyData & { assignedContributorId?: string })
-      ?.assignedContributorId === session?.user?.id ||
+    bounty.assignedContributorId === session?.user?.id ||
     bounty.submissions?.some((s) => s.submittedBy === session?.user?.id) ||
     (!isCreator && bounty.status === "IN_PROGRESS");
 
@@ -165,8 +161,7 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
   // BountyFieldsFragment (list query). The cast is safe here because
   // useBountyDetail returns BountyFieldsFragment & Partial<BountyQuery["bounty"]>.
   const competitionSubmissions =
-    (bounty as { submissions?: CompetitionSubmissionEntry[] | null })
-      .submissions ?? [];
+    (bounty.submissions as unknown as CompetitionSubmissionEntry[]) ?? [];
 
   return (
     <div className="flex flex-col lg:flex-row gap-10">

--- a/hooks/use-competition-join-state.ts
+++ b/hooks/use-competition-join-state.ts
@@ -9,6 +9,7 @@ import {
 } from "@/hooks/use-competition-bounty";
 import { useDeadlinePassed } from "@/hooks/use-deadline-passed";
 import type { BountyFieldsFragment } from "@/lib/graphql/generated";
+import type { Bounty } from "@/types/bounty";
 
 interface CompetitionJoinState {
   walletAddress: string | null;
@@ -19,7 +20,7 @@ interface CompetitionJoinState {
 }
 
 export function useCompetitionJoinState(
-  bounty: BountyFieldsFragment,
+  bounty: BountyFieldsFragment & Partial<Bounty>,
 ): CompetitionJoinState {
   const { data: session } = authClient.useSession();
   const joinMutation = useJoinCompetition();
@@ -38,9 +39,7 @@ export function useCompetitionJoinState(
   // Derive from server payload (submissions list on BountyQuery) + local optimism.
   // BountyFieldsFragment (list queries) doesn't include submissions, so falls
   // back to false until the detail query resolves.
-  const bountySubmissions = (
-    bounty as { submissions?: Array<{ submittedBy: string }> | null }
-  ).submissions;
+  const bountySubmissions = bounty.submissions;
   const serverHasJoined =
     walletAddress != null &&
     (bountySubmissions?.some((s) => s.submittedBy === walletAddress) ?? false);

--- a/types/bounty.ts
+++ b/types/bounty.ts
@@ -69,6 +69,17 @@ export interface BountyCount {
   submissions: number;
 }
 
+export interface BountyApplication {
+  id: string;
+  bountyId: string;
+  applicantAddress: string;
+  applicantName?: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  [key: string]: unknown;
+}
+
 export interface Milestone {
   id: string;
   title: string;
@@ -105,13 +116,17 @@ export interface Bounty {
   bountyWindow?: BountyWindowType | null;
 
   submissions?: BountySubmission[] | null;
+  applications?: BountyApplication[] | null;
   _count?: BountyCount | null;
 
   milestones?: Milestone[] | null;
   contributorProgress?: ContributorProgress[] | null;
+  assignedContributorId?: string | null;
 
   maxSlots?: number | null;
   totalSlotsOccupied?: number | null;
+  claimCount?: number | null;
+  maxParticipants?: number | null;
 
   createdBy: string;
   createdAt: string;


### PR DESCRIPTION
Fixes #211. Adds missing optional fields to the Bounty interface and removes ad-hoc casts across components and hooks.