### PR TITLE
feat: add Request Revisions action to submission approval panel

### DIFF
--- a/components/bounty-detail/bounty-detail-client.tsx
+++ b/components/bounty-detail/bounty-detail-client.tsx
@@ -168,6 +168,19 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
     (bounty as { submissions?: CompetitionSubmissionEntry[] | null })
       .submissions ?? [];
 
+  const mySubmission = bounty.submissions?.find(
+    (s) => s.submittedBy === session?.user?.id,
+  );
+  const hasRevision =
+    mySubmission?.status === "REVISION_REQUESTED" &&
+    !!mySubmission?.reviewComments;
+  const showSubmitPanel =
+    bounty.type === "MILESTONE_BASED" &&
+    isAssignedApplicant &&
+    !!walletAddress &&
+    (bounty.status === "IN_PROGRESS" ||
+      (bounty.status === "UNDER_REVIEW" && hasRevision));
+
   return (
     <div className="flex flex-col lg:flex-row gap-10">
       {/* Main content */}
@@ -240,33 +253,17 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
             />
           )}
 
-        {bounty.type === "MILESTONE_BASED" &&
-          isAssignedApplicant &&
-          walletAddress &&
-          (() => {
-            const mySubmission = bounty.submissions?.find(
-              (s) => s.submittedBy === session?.user?.id,
-            );
-            const hasRevision =
-              mySubmission?.status === "REVISION_REQUESTED" &&
-              !!mySubmission?.reviewComments;
-            return (
-              bounty.status === "IN_PROGRESS" ||
-              (bounty.status === "UNDER_REVIEW" && hasRevision)
-            );
-          })() && (
-            <ApplicationSubmitWorkPanel
-              bountyId={bountyId}
-              contributorAddress={walletAddress}
-              revisionFeedback={
-                bounty.submissions?.find(
-                  (s) =>
-                    s.submittedBy === session?.user?.id &&
-                    s.status === "REVISION_REQUESTED",
-                )?.reviewComments ?? undefined
-              }
-            />
-          )}
+        {showSubmitPanel && (
+          <ApplicationSubmitWorkPanel
+            bountyId={bountyId}
+            contributorAddress={walletAddress}
+            revisionFeedback={
+              hasRevision
+                ? (mySubmission?.reviewComments ?? undefined)
+                : undefined
+            }
+          />
+        )}
 
         {bounty.type === "MILESTONE_BASED" &&
           isCreator &&

--- a/components/bounty-detail/bounty-detail-client.tsx
+++ b/components/bounty-detail/bounty-detail-client.tsx
@@ -243,10 +243,28 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
         {bounty.type === "MILESTONE_BASED" &&
           isAssignedApplicant &&
           walletAddress &&
-          bounty.status === "IN_PROGRESS" && (
+          (() => {
+            const mySubmission = bounty.submissions?.find(
+              (s) => s.submittedBy === session?.user?.id,
+            );
+            const hasRevision =
+              mySubmission?.status === "REVISION_REQUESTED" &&
+              !!mySubmission?.reviewComments;
+            return (
+              bounty.status === "IN_PROGRESS" ||
+              (bounty.status === "UNDER_REVIEW" && hasRevision)
+            );
+          })() && (
             <ApplicationSubmitWorkPanel
               bountyId={bountyId}
               contributorAddress={walletAddress}
+              revisionFeedback={
+                bounty.submissions?.find(
+                  (s) =>
+                    s.submittedBy === session?.user?.id &&
+                    s.status === "REVISION_REQUESTED",
+                )?.reviewComments ?? undefined
+              }
             />
           )}
 
@@ -256,6 +274,7 @@ export function BountyDetailClient({ bountyId }: { bountyId: string }) {
             <SubmissionApprovalPanel
               bounty={bounty}
               creatorAddress={walletAddress}
+              submissionId={bounty.submissions?.[0]?.id}
               submittedWorkCid={
                 bounty.submissions?.[0]?.githubPullRequestUrl || undefined
               }

--- a/components/bounty/application-submit-work-panel.tsx
+++ b/components/bounty/application-submit-work-panel.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Upload, Link as LinkIcon, Send } from "lucide-react";
+import {
+  Upload,
+  Link as LinkIcon,
+  Send,
+  MessageSquareWarning,
+} from "lucide-react";
 import {
   Card,
   CardContent,
@@ -17,11 +22,13 @@ import { useSubmitApplicationWork } from "@/hooks/use-bounty-application";
 interface ApplicationSubmitWorkPanelProps {
   bountyId: string;
   contributorAddress: string;
+  revisionFeedback?: string;
 }
 
 export function ApplicationSubmitWorkPanel({
   bountyId,
   contributorAddress,
+  revisionFeedback,
 }: ApplicationSubmitWorkPanelProps) {
   const [workCid, setWorkCid] = useState("");
 
@@ -51,6 +58,21 @@ export function ApplicationSubmitWorkPanel({
         </CardDescription>
       </CardHeader>
       <CardContent className="pt-6">
+        {revisionFeedback && (
+          <div className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+            <div className="flex items-start gap-3">
+              <MessageSquareWarning className="size-5 text-amber-400 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-sm font-semibold text-amber-300 mb-1">
+                  Revision Requested
+                </p>
+                <p className="text-sm text-amber-200/80 whitespace-pre-wrap leading-relaxed">
+                  {revisionFeedback}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
             <Label htmlFor="work-cid">

--- a/components/bounty/submission-approval-panel.tsx
+++ b/components/bounty/submission-approval-panel.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   ExternalLink,
   ShieldCheck,
+  RotateCcw,
 } from "lucide-react";
 import {
   Card,
@@ -18,7 +19,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { useApproveApplicationSubmission } from "@/hooks/use-bounty-application";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+import {
+  useApproveApplicationSubmission,
+  useRequestRevisions,
+} from "@/hooks/use-bounty-application";
 import type { BountyFieldsFragment } from "@/lib/graphql/generated";
 import type { Bounty } from "@/types/bounty";
 
@@ -29,6 +35,7 @@ interface SubmissionApprovalPanelProps {
   creatorAddress: string;
   submittedWorkCid?: string;
   submissionDescription?: string;
+  submissionId?: string;
 }
 
 export function SubmissionApprovalPanel({
@@ -36,11 +43,17 @@ export function SubmissionApprovalPanel({
   creatorAddress,
   submittedWorkCid,
   submissionDescription,
+  submissionId,
 }: SubmissionApprovalPanelProps) {
   const [points, setPoints] = useState<number>(5);
+  const [showRevisionForm, setShowRevisionForm] = useState(false);
+  const [revisionFeedback, setRevisionFeedback] = useState("");
 
   const { mutate: approveSubmission, isPending: isApproving } =
     useApproveApplicationSubmission();
+
+  const { mutate: requestRevisions, isPending: isRequestingRevisions } =
+    useRequestRevisions();
 
   const handleApprove = () => {
     const clampedPoints = Math.max(1, Math.min(100, points || 0));
@@ -49,6 +62,27 @@ export function SubmissionApprovalPanel({
       creatorAddress,
       points: clampedPoints,
     });
+  };
+
+  const handleRequestRevisions = () => {
+    if (!submissionId || !revisionFeedback.trim()) return;
+    requestRevisions(
+      {
+        bountyId: bounty.id,
+        submissionId,
+        feedback: revisionFeedback.trim(),
+      },
+      {
+        onSuccess: () => {
+          toast.success("Revision request sent to contributor.");
+          setShowRevisionForm(false);
+          setRevisionFeedback("");
+        },
+        onError: () => {
+          toast.error("Failed to request revisions. Please try again.");
+        },
+      },
+    );
   };
 
   return (
@@ -131,25 +165,73 @@ export function SubmissionApprovalPanel({
             </Button>
           </div>
 
-          {/* Revision Section - Coming Soon */}
+          {/* Revision Section */}
           <div className="space-y-4 border-l border-gray-800/50 pl-6">
-            <div className="h-full flex flex-col justify-center items-center text-center p-4 border border-dashed border-gray-800 rounded-lg opacity-60">
-              <AlertTriangle className="size-6 text-gray-500 mb-2" />
-              <h4 className="text-sm font-medium text-gray-400 mb-1">
-                Needs Changes?
-              </h4>
-              <p className="text-xs text-gray-500 mb-4">
-                Request revisions before releasing the escrow.
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="border-gray-700 text-gray-500 cursor-not-allowed"
-                disabled
-              >
-                Coming Soon
-              </Button>
-            </div>
+            {!showRevisionForm ? (
+              <div className="h-full flex flex-col justify-center items-center text-center p-4 border border-dashed border-gray-800 rounded-lg">
+                <AlertTriangle className="size-6 text-amber-500 mb-2" />
+                <h4 className="text-sm font-medium text-gray-300 mb-1">
+                  Needs Changes?
+                </h4>
+                <p className="text-xs text-gray-500 mb-4">
+                  Request revisions before releasing the escrow.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-amber-700/50 text-amber-400 hover:bg-amber-500/10 hover:border-amber-600"
+                  onClick={() => setShowRevisionForm(true)}
+                  disabled={!submissionId}
+                >
+                  <RotateCcw className="size-3 mr-1.5" />
+                  Request Revisions
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div>
+                  <Label
+                    htmlFor="revision-feedback"
+                    className="text-sm font-medium text-gray-300"
+                  >
+                    Revision Feedback
+                  </Label>
+                  <p className="text-xs text-gray-500 mt-1 mb-2">
+                    Describe what needs to change before you can approve.
+                  </p>
+                  <Textarea
+                    id="revision-feedback"
+                    placeholder="Please update the API documentation to include error codes, and add unit tests for the authentication flow..."
+                    value={revisionFeedback}
+                    onChange={(e) => setRevisionFeedback(e.target.value)}
+                    className="bg-gray-900/50 border-gray-700 resize-none min-h-[100px]"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="flex-1 border-gray-700 text-gray-400"
+                    onClick={() => {
+                      setShowRevisionForm(false);
+                      setRevisionFeedback("");
+                    }}
+                    disabled={isRequestingRevisions}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    className="flex-1 bg-amber-500 hover:bg-amber-600 text-white"
+                    onClick={handleRequestRevisions}
+                    disabled={!revisionFeedback.trim() || isRequestingRevisions}
+                  >
+                    <RotateCcw className="size-3 mr-1.5" />
+                    {isRequestingRevisions ? "Sending..." : "Send Request"}
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </CardContent>

--- a/e2e/request-revisions.spec.ts
+++ b/e2e/request-revisions.spec.ts
@@ -54,7 +54,7 @@ const MOCK_BOUNTY_UNDER_REVIEW = {
       submittedBy: CONTRIBUTOR_ID,
       githubPullRequestUrl: "QmFakeIpfsCid1234",
       status: "PENDING",
-      reviewComments: null,
+      reviewComments: null as string | null,
       reviewedAt: null,
       reviewedBy: null,
       paidAt: null,

--- a/e2e/request-revisions.spec.ts
+++ b/e2e/request-revisions.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * E2E: Request Revisions Flow
+ *
+ * Tests the reviewer-side "Request Revisions" action on a MILESTONE_BASED bounty
+ * in UNDER_REVIEW status, and the contributor-side feedback banner.
+ *
+ * Stability strategy:
+ *   - GraphQL intercepted via page.route() - hermetic, no live backend.
+ *   - Selectors use visible text / roles only (no data-testid added to new UI yet).
+ *   - Timing via await expect(...) - no arbitrary sleeps.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const BOUNTY_ID = "e2ec0bcd-dead-beef-cafe-ab01cd02ef05";
+const SUBMISSION_ID = "sub-0001";
+const CREATOR_ID = "user-creator-001";
+const CONTRIBUTOR_ID = "user-contributor-001";
+const WALLET_ADDRESS =
+  "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGYWDOUALPIF5JD4PI21JQ";
+
+const MOCK_BOUNTY_UNDER_REVIEW = {
+  __typename: "Bounty",
+  id: BOUNTY_ID,
+  title: "Implement ZKP primitives",
+  description: "Build zero-knowledge proof primitives.",
+  status: "UNDER_REVIEW",
+  type: "MILESTONE_BASED",
+  rewardAmount: 1000,
+  rewardCurrency: "XLM",
+  createdAt: "2025-01-10T09:00:00Z",
+  updatedAt: "2025-01-24T14:20:00Z",
+  organizationId: "org-test",
+  projectId: null,
+  bountyWindowId: null,
+  githubIssueUrl: "https://github.com/test/repo/issues/1",
+  githubIssueNumber: 1,
+  createdBy: CREATOR_ID,
+  organization: {
+    __typename: "BountyOrganization",
+    id: "org-test",
+    name: "Test Org",
+    logo: null,
+    slug: "test-org",
+  },
+  project: null,
+  bountyWindow: null,
+  _count: { __typename: "BountyCount", submissions: 1 },
+  submissions: [
+    {
+      __typename: "BountySubmissionType",
+      id: SUBMISSION_ID,
+      bountyId: BOUNTY_ID,
+      submittedBy: CONTRIBUTOR_ID,
+      githubPullRequestUrl: "QmFakeIpfsCid1234",
+      status: "PENDING",
+      reviewComments: null,
+      reviewedAt: null,
+      reviewedBy: null,
+      paidAt: null,
+      rewardTransactionHash: null,
+      createdAt: "2025-01-20T10:00:00Z",
+      updatedAt: "2025-01-20T10:00:00Z",
+      submittedByUser: {
+        __typename: "BountySubmissionUser",
+        id: CONTRIBUTOR_ID,
+        name: "Test Contributor",
+        image: null,
+      },
+      reviewedByUser: null,
+    },
+  ],
+  milestones: [{ id: "m1", title: "Milestone 1", isCompleted: false }],
+  contributorProgress: null,
+  maxSlots: null,
+  totalSlotsOccupied: null,
+};
+
+const MOCK_BOUNTY_WITH_REVISION = {
+  ...MOCK_BOUNTY_UNDER_REVIEW,
+  submissions: [
+    {
+      ...MOCK_BOUNTY_UNDER_REVIEW.submissions[0],
+      status: "REVISION_REQUESTED",
+      reviewComments: "Please add unit tests for the auth flow.",
+    },
+  ],
+};
+
+function makeSession(userId: string) {
+  return {
+    user: {
+      id: userId,
+      name: userId === CREATOR_ID ? "Test Creator" : "Test Contributor",
+      email: `${userId}@test.com`,
+      image: null,
+      walletAddress: WALLET_ADDRESS,
+    },
+    session: { token: "fake-e2e-token" },
+  };
+}
+
+async function setupMocks(
+  page: Page,
+  options: {
+    userId: string;
+    bountyData?: typeof MOCK_BOUNTY_UNDER_REVIEW;
+    revisionMutationResult?: object;
+  },
+) {
+  const {
+    userId,
+    bountyData = MOCK_BOUNTY_UNDER_REVIEW,
+    revisionMutationResult,
+  } = options;
+
+  await page.route("**/api/auth/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      url.pathname.endsWith("/get-session") ||
+      url.pathname.endsWith("/session")
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeSession(userId)),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    }
+  });
+
+  await page.route("**/api/graphql", async (route) => {
+    let body: { operationName?: string } = {};
+    try {
+      body = JSON.parse(route.request().postData() ?? "{}") as {
+        operationName?: string;
+      };
+    } catch {
+      /* ignore */
+    }
+
+    switch (body.operationName) {
+      case "Bounty":
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: { bounty: bountyData } }),
+        });
+        return;
+      case "ReviewSubmission":
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            data: {
+              reviewSubmission:
+                revisionMutationResult ??
+                MOCK_BOUNTY_WITH_REVISION.submissions[0],
+            },
+          }),
+        });
+        return;
+      case "TopContributors":
+      case "Leaderboard":
+      case "GetLeaderboardUser":
+      case "LeaderboardUser":
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: {} }),
+        });
+        return;
+      default:
+        await route.abort("failed");
+    }
+  });
+
+  await page.context().addCookies([
+    {
+      name: "boundless_auth.session_token",
+      value: "fake-e2e-token",
+      domain: "localhost",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+// ── Reviewer side ──────────────────────────────────────────────────────────
+
+test.describe("Request Revisions — reviewer side", () => {
+  // CardTitle renders as <div>, not <h*>, so we use getByText instead of getByRole("heading")
+  test("approval panel is visible when bounty is UNDER_REVIEW and user is creator", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await expect(page.getByText("Review Submission").first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("clicking Request Revisions reveals feedback textarea", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await expect(page.getByText("Review Submission").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: /Request Revisions/i }).click();
+    await expect(page.getByLabel(/Revision Feedback/i)).toBeVisible();
+  });
+
+  test("Send Request is disabled when textarea is empty", async ({ page }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await expect(page.getByText("Review Submission").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: /Request Revisions/i }).click();
+    await expect(
+      page.getByRole("button", { name: /Send Request/i }),
+    ).toBeDisabled();
+  });
+
+  test("submitting feedback shows success toast and resets panel", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await expect(page.getByText("Review Submission").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: /Request Revisions/i }).click();
+    await page
+      .getByLabel(/Revision Feedback/i)
+      .fill("Please add unit tests for the auth flow.");
+    await page.getByRole("button", { name: /Send Request/i }).click();
+
+    await expect(page.getByText(/Revision request sent/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Panel resets — textarea gone, button visible again
+    await expect(page.getByLabel(/Revision Feedback/i)).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Request Revisions/i }),
+    ).toBeVisible();
+  });
+
+  test("Cancel button hides textarea without submitting", async ({ page }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await expect(page.getByText("Review Submission").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: /Request Revisions/i }).click();
+    await page.getByLabel(/Revision Feedback/i).fill("Some feedback");
+    await page.getByRole("button", { name: /Cancel/i }).click();
+
+    await expect(page.getByLabel(/Revision Feedback/i)).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Request Revisions/i }),
+    ).toBeVisible();
+  });
+});
+
+// ── Contributor side ───────────────────────────────────────────────────────
+
+test.describe("Request Revisions — contributor side", () => {
+  test("revision feedback banner is visible when submission has REVISION_REQUESTED status", async ({
+    page,
+  }) => {
+    await setupMocks(page, {
+      userId: CONTRIBUTOR_ID,
+      bountyData: {
+        ...MOCK_BOUNTY_WITH_REVISION,
+        status: "UNDER_REVIEW",
+      },
+    });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+
+    await expect(page.getByText(/Revision Requested/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByText(/Please add unit tests for the auth flow\./i),
+    ).toBeVisible();
+  });
+
+  test("submit work form is still visible so contributor can resubmit", async ({
+    page,
+  }) => {
+    await setupMocks(page, {
+      userId: CONTRIBUTOR_ID,
+      bountyData: {
+        ...MOCK_BOUNTY_WITH_REVISION,
+        status: "UNDER_REVIEW",
+      },
+    });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+
+    await expect(page.getByText("Submit Your Work").first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -4,7 +4,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { authClient } from "@/lib/auth-client";
 import { bountyKeys } from "@/lib/query/query-keys";
 import { MOCK_MODEL4_MILESTONES } from "@/lib/mock/model4";
-import type { BountyQuery } from "@/lib/graphql/generated";
+import { fetcher } from "@/lib/graphql/client";
+import {
+  ReviewSubmissionDocument,
+  type BountyQuery,
+  type ReviewSubmissionMutation,
+  type ReviewSubmissionMutationVariables,
+} from "@/lib/graphql/generated";
 import type { ContributorProgress, Bounty } from "@/types/bounty";
 
 // ---------------------------------------------------------------------------
@@ -240,6 +246,66 @@ export function useApproveApplicationSubmission() {
           bounty: {
             ...prev.bounty,
             status: "COMPLETED",
+            updatedAt: new Date().toISOString(),
+          },
+        });
+      }
+      return { prev, bountyId };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(bountyKeys.detail(ctx.bountyId), ctx.prev);
+    },
+    onSettled: (_r, _e, v) => {
+      qc.invalidateQueries({ queryKey: bountyKeys.detail(v.bountyId) });
+      qc.invalidateQueries({ queryKey: bountyKeys.lists() });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hook: request revisions (reviewSubmission with status REVISION_REQUESTED)
+// ---------------------------------------------------------------------------
+
+type RequestRevisionsVars = {
+  bountyId: string;
+  submissionId: string;
+  feedback: string;
+};
+
+type RequestRevisionsCtx = {
+  prev: BountyQuery | undefined;
+  bountyId: string;
+};
+
+export function useRequestRevisions() {
+  const qc = useQueryClient();
+
+  return useMutation<
+    ReviewSubmissionMutation,
+    Error,
+    RequestRevisionsVars,
+    RequestRevisionsCtx
+  >({
+    mutationFn: ({ submissionId, feedback }) =>
+      fetcher<ReviewSubmissionMutation, ReviewSubmissionMutationVariables>(
+        ReviewSubmissionDocument,
+        {
+          input: {
+            submissionId,
+            status: "REVISION_REQUESTED",
+            reviewComments: feedback,
+          },
+        },
+      )(),
+    onMutate: async ({ bountyId }) => {
+      await qc.cancelQueries({ queryKey: bountyKeys.detail(bountyId) });
+      const prev = qc.getQueryData<BountyQuery>(bountyKeys.detail(bountyId));
+      if (prev?.bounty) {
+        qc.setQueryData<BountyQuery>(bountyKeys.detail(bountyId), {
+          ...prev,
+          bounty: {
+            ...prev.bounty,
+            status: "UNDER_REVIEW",
             updatedAt: new Date().toISOString(),
           },
         });


### PR DESCRIPTION
## Closes #202 

## Summary

  - Adds `useRequestRevisions` mutation following same shape as `useApproveApplicationSubmission` (optimistic update → `UNDER_REVIEW`, rollback on error)
  - Re-enables the Request Revisions button in `SubmissionApprovalPanel`; clicking reveals a textarea for feedback wired to the new mutation with success toast and panel reset
  - Surfaces `reviewComments` as a revision feedback banner in `ApplicationSubmitWorkPanel` so contributors see what needs changing before resubmitting
  - Updates `bounty-detail-client.tsx` to pass `submissionId` and `revisionFeedback` props (required to wire the new behavior end-to-end)

  ## Test plan

  - [x] `useRequestRevisions` accepts `bountyId`, `submissionId`, `feedback`
  - [x] Optimistic update sets bounty status to `UNDER_REVIEW`; rolls back on error
  - [x] Reviewer clicks Request Revisions → textarea reveals → submits feedback → success toast → panel resets
  - [x] Cancel button hides textarea without submitting
  - [x] Send Request disabled when textarea empty
  - [x] Contributor sees "Revision Requested" banner with feedback text
  - [x] Contributor submit form visible when revision pending (7 E2E tests, all passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reviewers can request revisions on submissions with detailed feedback; creators can send revision requests from the approval panel.
  * Contributors receive visible revision feedback (a “Revision Requested” notice) and can resubmit work while preserving the submit form.

* **Tests**
  * Added end-to-end tests covering the full request-revisions flow and contributor/creator UI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->