### PR TITLE
fix(create): escape apostrophe in placeholder copy

### DIFF
--- a/app/bounty/create/page.tsx
+++ b/app/bounty/create/page.tsx
@@ -44,8 +44,8 @@ export default function CreateBountyPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="text-sm text-amber-900">
-          We're building a powerful form to help you create bounties. Check back
-          soon!
+          We&apos;re building a powerful form to help you create bounties. Check
+          back soon!
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
Fixes the `react/no-unescaped-entities` lint error introduced by #254 on `app/bounty/create/page.tsx:47`. The placeholder copy had an unescaped `'` in "We're" which was failing CI build-and-lint. Replaced with `We&apos;re`.

`pnpm lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor text formatting update on the bounty creation page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/bounties/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->