### PR TITLE
fix(ci): restore --with-deps on Playwright install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT: ${{ secrets.NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT || 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC' }}
 
       - name: Install Playwright Chromium
-        run: pnpm exec playwright install chromium
+        run: pnpm exec playwright install chromium --with-deps
 
       - name: Run E2E tests
         run: pnpm run test:e2e


### PR DESCRIPTION
PR #265 dropped `--with-deps` from the Playwright install step in `.github/workflows/ci.yml`. Without it, fresh CI runners without Chromium's system libs (fonts, shared libraries) cached will fail to launch the browser.

Restoring `--with-deps` so e2e stays reliable across cold runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E test environment setup to ensure all required system dependencies are properly installed before running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->