### PR TITLE
fix(decline-applicant): remove runtime crash and clean up state

### DIFF
--- a/components/bounty/application-review-dashboard.tsx
+++ b/components/bounty/application-review-dashboard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   Users,
   CheckCircle,
@@ -59,14 +59,14 @@ export function ApplicationReviewDashboard({
   applications,
 }: ApplicationReviewDashboardProps) {
   const [selectedForCompare, setSelectedForCompare] = useState<string[]>([]);
-  const [reviewApplications, setReviewApplications] = useState(applications);
   const [declineTarget, setDeclineTarget] = useState<Application | null>(null);
   const [declineReason, setDeclineReason] = useState("");
+
   const { mutate: selectApplicant, isPending: isSelecting } =
     useSelectApplicant();
-  useEffect(() => {
-    setReviewApplications(applications);
-  }, [applications]);
+  const { mutate: declineApplicant, isPending: isDeclining } =
+    useDeclineApplicant();
+
   const handleSelectApplicant = (applicantAddress: string) => {
     selectApplicant({
       bountyId,
@@ -75,20 +75,13 @@ export function ApplicationReviewDashboard({
     });
   };
 
-  const { mutate: declineApplicant, isPending: isDeclining } =
-    useDeclineApplicant();
-
   const handleDeclineApplicant = () => {
     if (!declineTarget) return;
 
-    const previousApplications = reviewApplications;
     const applicantAddress = declineTarget.applicantAddress;
     const reason = declineReason.trim();
 
-    setReviewApplications((current) =>
-      current.filter((app) => app.applicantAddress !== applicantAddress),
-    );
-
+    // Drop the declined applicant from the comparison set if it was selected
     setSelectedForCompare((current) =>
       current.filter((id) => id !== declineTarget.id),
     );
@@ -106,13 +99,13 @@ export function ApplicationReviewDashboard({
           setDeclineReason("");
         },
         onError: () => {
-          setReviewApplications(previousApplications);
           toast.error("Failed to decline applicant");
         },
       },
     );
   };
-  const visibleApplications = reviewApplications;
+
+  const visibleApplications = applications;
   const toggleCompare = (id: string) => {
     if (selectedForCompare.includes(id)) {
       setSelectedForCompare(selectedForCompare.filter((i) => i !== id));
@@ -314,7 +307,3 @@ export function ApplicationReviewDashboard({
     </div>
   );
 }
-function useEffect(arg0: () => void, arg1: Application[][]) {
-  throw new Error("Function not implemented.");
-}
-

--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -184,7 +184,6 @@ type DeclinedApplicationRecord = {
   bountyId?: string;
   applicantAddress?: string;
   status?: string;
-  declinedReason?: string;
   declineReason?: string;
   declinedAt?: string;
 };
@@ -237,7 +236,6 @@ export function useDeclineApplicant() {
                       ...application,
                       status: "DECLINED",
                       declineReason: reason?.trim() || undefined,
-                      declinedReason: reason?.trim() || undefined,
                       declinedAt,
                     }
                   : application,


### PR DESCRIPTION
Cleanup for the three issues from PR #253 that landed unaddressed despite multiple review rounds.

## Changes

`components/bounty/application-review-dashboard.tsx`
* Removed the fake `useEffect` stub at the bottom of the file that threw `Error: Function not implemented.` whenever the parent re-rendered with new applications. The hook was used at line 67 but never imported; an AI-generated placeholder satisfied the type checker while crashing at runtime.
* Removed the local `reviewApplications` mirror state. The `useDeclineApplicant` hook already updates the React Query cache optimistically, so the parent re-render delivers the filtered list automatically. Single source of truth.
* Removed the unused `useMemo` import.

`hooks/use-bounty-application.ts`
* Dropped the duplicate `declinedReason` field that was being set alongside `declineReason` with the same value. Kept `declineReason` since it matches the mutation input name.

## Verified

* `pnpm tsc --noEmit` clean
* `pnpm lint` clean (only the pre-existing `server-graphql.ts` warning)