### PR TITLE
Remove redundant Bounty casts in bounty card slots

### DIFF
--- a/components/bounty/bounty-card.tsx
+++ b/components/bounty/bounty-card.tsx
@@ -20,7 +20,7 @@ import { getRoundPhase } from "@/hooks/use-lightning-rounds";
 import { BookmarkButton } from "./bookmark-button";
 
 interface BountyCardProps {
-  bounty: BountyFieldsFragment;
+  bounty: BountyFieldsFragment & Partial<Bounty>;
   onClick?: () => void;
   variant?: "grid" | "list";
 }
@@ -229,7 +229,7 @@ export function BountyCard({
             {bounty.type === "MULTI_WINNER_MILESTONE" && (
               <Badge className="bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 text-xs px-2.5 py-1 flex items-center gap-1">
                 <Users className="size-3" />
-                {(bounty as unknown as Bounty).totalSlotsOccupied ?? 0} / {(bounty as unknown as Bounty).maxSlots ?? 5} slots
+                {bounty.totalSlotsOccupied ?? 0} / {bounty.maxSlots ?? 5} slots
               </Badge>
             )}
           </div>


### PR DESCRIPTION
## Summary
- widen `BountyCardProps.bounty` to `BountyFieldsFragment & Partial<Bounty>`
- remove obsolete `as unknown as Bounty` casts from the multi-winner slot count display

## Validation
- Confirmed no `(bounty as unknown as Bounty)` casts remain in `components/bounty/bounty-card.tsx`
- Confirmed no `(bounty as { ... })` casts remain in `components/bounty/bounty-card.tsx`

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounty card handling so competition slot counts display correctly when optional bounty details are present.
  * Reduced the chance of missing or incorrect slot information in the bounty view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->