### PR TITLE
Fix navbar rank and credits user session binding

### DIFF
--- a/components/global-navbar.tsx
+++ b/components/global-navbar.tsx
@@ -22,11 +22,13 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useUserRole } from "@/hooks/use-user-role";
+import { authClient } from "@/lib/auth-client";
 
 import { Wallet, LogIn, Fingerprint } from "lucide-react";
 
 export function GlobalNavbar() {
   const pathname = usePathname();
+  const { data: session } = authClient.useSession();
   const userRole = useUserRole();
   const { walletInfo, isConnected, isRegistered, connect, isLoading } =
     useSmartWallet();
@@ -51,6 +53,7 @@ export function GlobalNavbar() {
     has2FA: false,
     isConnected: false,
   };
+  const currentUserId = session?.user?.id;
 
   return (
     <nav className="border-b sticky top-0 z-50 w-full bg-background">
@@ -140,9 +143,12 @@ export function GlobalNavbar() {
         </div>
 
         <div className="flex items-center gap-3">
-          <NavRankBadge userId="user-1" className="hidden sm:flex" />
-          <CreditBalance userId="user-1" className="hidden sm:flex" />
-          {/* TODO: Replace with actual auth user ID */}
+          {currentUserId && (
+            <>
+              <NavRankBadge userId={currentUserId} className="hidden sm:flex" />
+              <CreditBalance userId={currentUserId} className="hidden sm:flex" />
+            </>
+          )}
 
           <NotificationCenter />
 

--- a/components/ui/global-resizable-navbar.tsx
+++ b/components/ui/global-resizable-navbar.tsx
@@ -14,8 +14,11 @@ import {
 import { NavRankBadge } from "@/components/leaderboard/nav-rank-badge";
 import { SearchCommand } from "@/components/search-command";
 import { ModeToggle } from "@/components/mode-toggle";
+import { authClient } from "@/lib/auth-client";
 
 export default function GlobalResizableNavbar() {
+  const { data: session } = authClient.useSession();
+  const currentUserId = session?.user?.id;
 
   const navItems = [
     { name: "Explore", link: "/bounty" },
@@ -37,7 +40,7 @@ export default function GlobalResizableNavbar() {
         <NavItems items={navItems} />
 
         <div className="flex items-center gap-2">
-          <NavRankBadge userId="user-1" className="hidden sm:flex" />
+          <NavRankBadge userId={currentUserId} className="hidden sm:flex" />
           <SearchCommand />
           <ModeToggle />
         </div>


### PR DESCRIPTION
Closes #272

## Summary
- replace hardcoded `user-1` navbar rank/credit bindings with the authenticated session user id
- hide credit/rank widgets until a session user id is available instead of querying placeholder data
- update the resizable navbar rank badge to use the same session-backed id

## Validation
- `npx --no-install tsc --noEmit`
- `npm run lint -- components/global-navbar.tsx components/ui/global-resizable-navbar.tsx`

Note: dependencies were installed locally with `npm install --ignore-scripts` because a transitive Windows lifecycle script uses POSIX `|| true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-specific navbar elements now appear based on the signed-in session, instead of a placeholder account ID.
  * Improved consistency in the top navigation by tying rank and balance displays to the current user when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->