### PR TITLE
Replace mock maintainer flag with user role check

### DIFF
--- a/components/bounty/bounty-sidebar.tsx
+++ b/components/bounty/bounty-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { RatingModal } from "../rating/rating-modal";
 import { useClaimBounty } from "@/hooks/use-bounty-mutations";
+import { useUserRole } from "@/hooks/use-user-role";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import type {
@@ -27,18 +28,8 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
   const [copied, setCopied] = useState(false);
   const claimBounty = useClaimBounty();
   const [loading, setLoading] = useState(false);
-
-  // Mock maintainer check for now - in real app this comes from auth context
-  const IS_MAINTAINER = process.env.NEXT_PUBLIC_MOCK_MAINTAINER === "true";
-
-  if (
-    typeof window !== "undefined" &&
-    process.env.NEXT_PUBLIC_MOCK_MAINTAINER === "true"
-  ) {
-    console.warn(
-      "DEV: Mock maintainer enabled in components/bounty/bounty-sidebar.tsx — do NOT enable in production",
-    );
-  }
+  const userRole = useUserRole();
+  const isMaintainer = userRole === "sponsor";
 
   const createdTimeAgo = useMemo(
     () => formatDistanceToNow(new Date(bounty.createdAt), { addSuffix: true }),
@@ -90,7 +81,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
   } | null>(null);
 
   const handleMarkCompleted = async () => {
-    if (!IS_MAINTAINER) {
+    if (!isMaintainer) {
       alert("Only maintainers can mark as completed.");
       return;
     }
@@ -121,7 +112,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
       alert("You have already rated this contributor.");
       return;
     }
-    if (!IS_MAINTAINER) {
+    if (!isMaintainer) {
       alert("Only maintainers can rate contributors.");
       return;
     }
@@ -142,7 +133,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
   };
 
   const renderActionButton = () => {
-    if (bounty.status === "IN_PROGRESS" && IS_MAINTAINER && !completed) {
+    if (bounty.status === "IN_PROGRESS" && isMaintainer && !completed) {
       return (
         <Button
           onClick={handleMarkCompleted}
@@ -205,7 +196,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
       {lastRating && reputationGain && (
         <div className="p-4 mb-4 rounded bg-green-900/60 text-green-200 border border-green-700">
           <div className="mb-1">
-            {IS_MAINTAINER
+            {isMaintainer
               ? "You rated the contributor:"
               : "Contributor was rated:"}{" "}
             <b>{lastRating} / 5</b> stars


### PR DESCRIPTION
## Summary
- Replace the `NEXT_PUBLIC_MOCK_MAINTAINER` gate in `BountySidebar` with the existing `useUserRole()` hook
- Show maintainer-only completion/rating UI only when the current user role is `sponsor`
- Remove the dev-only console warning tied to the mock maintainer env flag

Closes #274

## Validation
- `pnpm install --frozen-lockfile` with pnpm 10.25.0
- `pnpm lint` *(passes with one existing warning in `lib/server-graphql.ts`)*
- `pnpm build`

## Notes
- The diff is intentionally limited to `components/bounty/bounty-sidebar.tsx`.
- `pnpm exec tsc --noEmit` still hits the repo's pre-existing missing `@jest/globals` test dependency in `components/reputation/__tests__/my-claims.test.ts`, so this PR leaves that unrelated dependency cleanup out of scope.
- Vercel is blocked by external fork deployment authorization.
