### PR TITLE
#279 Rebuild components/rating/rating-modal.tsx with shadcn Dialog pr…

### DIFF
--- a/components/rating/rating-modal.tsx
+++ b/components/rating/rating-modal.tsx
@@ -1,5 +1,18 @@
-import React, { useState } from 'react';
-import { RatingStars } from './rating-stars';
+"use client";
+
+import { useState } from "react";
+import type React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { RatingStars } from "./rating-stars";
 
 interface RatingModalProps {
   contributor: {
@@ -15,16 +28,21 @@ interface RatingModalProps {
   onClose: () => void;
 }
 
-export const RatingModal: React.FC<RatingModalProps> = ({ contributor, bounty, onSubmit, onClose }) => {
+export const RatingModal = ({
+  contributor,
+  bounty,
+  onSubmit,
+  onClose,
+}: RatingModalProps) => {
   const [rating, setRating] = useState(0);
-  const [feedback, setFeedback] = useState('');
+  const [feedback, setFeedback] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
   const handleSubmit = async () => {
     if (rating < 1 || rating > 5) {
-      setError('Please select a rating between 1 and 5.');
+      setError("Please select a rating between 1 and 5.");
       return;
     }
     setLoading(true);
@@ -33,50 +51,79 @@ export const RatingModal: React.FC<RatingModalProps> = ({ contributor, bounty, o
       await onSubmit(rating, feedback);
       setSuccess(true);
     } catch (err) {
-      console.error(err)
-      setError('Failed to submit rating. Please try again.');
+      console.error(err);
+      setError("Failed to submit rating. Please try again.");
     } finally {
       setLoading(false);
     }
   };
 
-  if (success) {
-    return (
-      <div className="modal">
-        <h2>Success!</h2>
-        <p>Rating submitted. Contributor reputation updated.</p>
-        <button onClick={onClose}>Close</button>
-      </div>
-    );
-  }
-
   return (
-    <div className="modal">
-      <h2>Rate Contributor</h2>
-      <div>
-        <strong>Bounty:</strong> {bounty.title}
-      </div>
-      <div>
-        <strong>Contributor:</strong> {contributor.name}
-      </div>
-      <div>
-        <strong>Current Reputation:</strong> {contributor.reputation}
-      </div>
-      <div style={{ margin: '16px 0' }}>
-        <RatingStars value={rating} onChange={setRating} />
-      </div>
-      <textarea
-        placeholder="Optional feedback"
-        value={feedback}
-        onChange={e => setFeedback(e.target.value)}
-        rows={3}
-        style={{ width: '100%', marginBottom: 8 }}
-      />
-      {error && <div style={{ color: 'red', marginBottom: 8 }}>{error}</div>}
-      <button onClick={handleSubmit} disabled={loading}>
-        {loading ? 'Submitting...' : 'Submit'}
-      </button>
-      <button onClick={onClose} style={{ marginLeft: 8 }}>Cancel</button>
-    </div>
+    <Dialog open onOpenChange={(open: boolean) => !open && onClose()}>
+      <DialogContent>
+        {success ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Success!</DialogTitle>
+              <DialogDescription>
+                Rating submitted. Contributor reputation updated.
+              </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter>
+              <Button variant="ghost" onClick={onClose}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Rate Contributor</DialogTitle>
+              <DialogDescription>
+                Provide a rating and optional feedback for the contributor.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-2">
+              <div>
+                <strong>Bounty:</strong> {bounty.title}
+              </div>
+              <div>
+                <strong>Contributor:</strong> {contributor.name}
+              </div>
+              <div>
+                <strong>Current Reputation:</strong> {contributor.reputation}
+              </div>
+
+              <div className="mt-4">
+                <RatingStars value={rating} onChange={setRating} />
+              </div>
+
+              <Textarea
+                placeholder="Optional feedback"
+                value={feedback}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setFeedback(e.target.value)
+                }
+                rows={3}
+                className="min-h-[6rem]"
+              />
+
+              {error && <div className="text-destructive">{error}</div>}
+            </div>
+
+            <DialogFooter>
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleSubmit} disabled={loading}>
+                {loading ? "Submitting..." : "Submit"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/components/rating/rating-modal.tsx
+++ b/components/rating/rating-modal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import type React from "react";
 import {
   Dialog,
   DialogContent,
@@ -86,14 +85,21 @@ export const RatingModal = ({
             </DialogHeader>
 
             <div className="space-y-2">
-              <div>
-                <strong>Bounty:</strong> {bounty.title}
+              <div className="flex items-center">
+                <span className="text-muted-foreground">Bounty:</span>
+                <span className="ml-2 font-medium">{bounty.title}</span>
               </div>
-              <div>
-                <strong>Contributor:</strong> {contributor.name}
+              <div className="flex items-center">
+                <span className="text-muted-foreground">Contributor:</span>
+                <span className="ml-2 font-medium">{contributor.name}</span>
               </div>
-              <div>
-                <strong>Current Reputation:</strong> {contributor.reputation}
+              <div className="flex items-center">
+                <span className="text-muted-foreground">
+                  Current Reputation:
+                </span>
+                <span className="ml-2 font-medium">
+                  {contributor.reputation}
+                </span>
               </div>
 
               <div className="mt-4">
@@ -103,9 +109,7 @@ export const RatingModal = ({
               <Textarea
                 placeholder="Optional feedback"
                 value={feedback}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setFeedback(e.target.value)
-                }
+                onChange={(e) => setFeedback(e.target.value)}
                 rows={3}
                 className="min-h-[6rem]"
               />

--- a/components/rating/rating-stars.tsx
+++ b/components/rating/rating-stars.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
 interface RatingStarsProps {
   value: number;
@@ -7,39 +7,51 @@ interface RatingStarsProps {
   displayOnly?: boolean;
 }
 
-export const RatingStars: React.FC<RatingStarsProps> = ({ value, onChange, disabled, displayOnly }) => {
+export const RatingStars: React.FC<RatingStarsProps> = ({
+  value,
+  onChange,
+  disabled,
+  displayOnly,
+}) => {
   const [hovered, setHovered] = useState<number | null>(null);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!onChange || disabled || displayOnly) return;
-    if (e.key === 'ArrowLeft' && value > 1) onChange(value - 1);
-    if (e.key === 'ArrowRight' && value < 5) onChange(value + 1);
+    if (e.key === "ArrowLeft" && value > 1) onChange(value - 1);
+    if (e.key === "ArrowRight" && value < 5) onChange(value + 1);
   };
 
   return (
     <div
       tabIndex={displayOnly ? -1 : 0}
-      role={displayOnly ? 'img' : 'slider'}
+      role={displayOnly ? "img" : "slider"}
       aria-valuenow={value}
       aria-valuemin={1}
       aria-valuemax={5}
       onKeyDown={handleKeyDown}
-      style={{ display: 'flex', gap: 4, outline: 'none', cursor: displayOnly ? 'default' : 'pointer' }}
+      className={
+        displayOnly
+          ? "flex items-center gap-1 outline-none"
+          : "flex items-center gap-1 cursor-pointer outline-none"
+      }
     >
       {[1, 2, 3, 4, 5].map((star) => (
         <span
           key={star}
           onMouseEnter={() => !displayOnly && setHovered(star)}
           onMouseLeave={() => !displayOnly && setHovered(null)}
-          onClick={() => onChange && !disabled && !displayOnly && onChange(star)}
-          style={{
-            color: (hovered ?? value) >= star ? '#FFD700' : '#CCC',
-            fontSize: 28,
-            transition: 'color 0.2s',
-            pointerEvents: displayOnly ? 'none' : 'auto',
-            userSelect: 'none',
-          }}
-          aria-label={star + ' star'}
+          onClick={() =>
+            onChange && !disabled && !displayOnly && onChange(star)
+          }
+          className={
+            displayOnly
+              ? "select-none text-2xl text-muted-foreground"
+              : "select-none text-2xl transition-colors duration-200 " +
+                ((hovered ?? value) >= star
+                  ? "text-yellow-400"
+                  : "text-muted-foreground")
+          }
+          aria-label={star + " star"}
         >
           ★
         </span>


### PR DESCRIPTION
Rebuild rating-modal.tsx with shadcn Dialog primitives
---
closes #279 
---
Summary
components/rating/rating-modal.tsx was the only dialog in the repo using raw HTML and inline styles instead of the project's design system. This PR rebuilds it on the shadcn primitives that every other dialog uses, with semantic design tokens throughout. Props and behavior are unchanged, so the existing caller in components/bounty/bounty-sidebar.tsx keeps working without modification.
---
What changed
components/rating/rating-modal.tsx rebuilt with:
Dialog + DialogContent + DialogHeader + DialogTitle + DialogDescription + DialogFooter from components/ui/dialog
Button from components/ui/button — variant="ghost" for Cancel/Close, default variant for Submit
Textarea from components/ui/textarea
All style={{...}} replaced with Tailwind utility classes
Error text now uses the text-destructive token instead of color: 'red'
Open/close wired through Dialog's onOpenChange, preserving the existing onClose contract
components/rating/rating-stars.tsx updated to drop inline styles in favor of Tailwind classes / semantic tokens (text-muted-foreground, text-yellow-400) as part of removing all inline styling from this surface.
Props & behavior preserved
Props unchanged: contributor, bounty, onSubmit, onClose — no caller changes required (components/bounty/bounty-sidebar.tsx still works as-is).
Submit validates the 1–5 rating, calls onSubmit, shows a loading state, and renders the success state on resolve.
Error state renders correctly with the destructive token; Cancel/Close behave identically to before.
---
Acceptance criteria
 No raw <div className="modal">, raw <button>, raw <textarea>, or style={{...}} in the file
 Modal matches the visual treatment of other AlertDialogs in the bounty surface
 Submit and Cancel buttons behave identically to before
 Success and error states render correctly
 pnpm tsc --noEmit passes (no new errors from these files)
 pnpm lint passes (0 errors)
---
Testing
pnpm tsc --noEmit — clean for the rating components (the only remaining error is a pre-existing, unrelated @jest/globals types issue in components/reputation/__tests__/my-claims.test.ts).
pnpm lint — 0 errors (1 pre-existing unused-var warning in lib/server-graphql.ts, unrelated to this change).
npx eslint components/rating/rating-modal.tsx components/rating/rating-stars.tsx — exit 0.
---
Files
components/rating/rating-modal.tsx
components/rating/rating-stars.tsx
---
please kindly review and if there is any update regarding the task, please do let know!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the rating popup to use a polished dialog layout with clearer header, footer, and success state.
  * Improved the rating control styling for more consistent interactive and read-only presentation.

* **Bug Fixes**
  * Enhanced rating submission error handling with clearer failure messaging and reliable loading-state cleanup.
  * Improved dialog dismissal behavior for more consistent closing interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---
Pushed the requested polish:
- Bounty/Contributor/Current Reputation now use the muted-label + value pattern (matches tier-upgrade-dialog.tsx)
- Removed the unnecessary explicit React.ChangeEvent annotation on the Textarea onChange

Screenshots attached below for both the default form and success state. initial
<img width="1919" height="995" alt="image" src="https://github.com/user-attachments/assets/e50be5fa-ceb5-4de0-b9d6-0d2820534cd3" /> 
success 
<img width="1919" height="1005" alt="image" src="https://github.com/user-attachments/assets/c583d9ab-cf4e-4938-8509-6a0ab9ff1f61" />
