### PR TITLE
refactor(bounty-card): remove unsafe Bounty casts for slot counts

### DIFF
--- a/components/bounty/bounty-card.tsx
+++ b/components/bounty/bounty-card.tsx
@@ -19,10 +19,11 @@ import { useEscrowPool } from "@/hooks/use-escrow";
 import { getRoundPhase } from "@/hooks/use-lightning-rounds";
 import { BookmarkButton } from "./bookmark-button";
 
-type CardBounty = BountyFieldsFragment & Partial<Bounty>;
+type CardBounty = BountyFieldsFragment &
+  Partial<Pick<Bounty, "totalSlotsOccupied" | "maxSlots">>;
 
 interface BountyCardProps {
-  bounty: BountyFieldsFragment;
+  bounty: CardBounty;
   onClick?: () => void;
   variant?: "grid" | "list";
 }
@@ -95,7 +96,6 @@ export function BountyCard({
   const isFcfsClaimed =
     bounty.type === "FIXED_PRICE" && normalizedStatus === "IN_PROGRESS";
   const isCompetition = bounty.type === "COMPETITION";
-  const cardBounty = bounty as CardBounty;
   // claimCount and maxParticipants are pending backend schema fields; use safe fallbacks.
   const slotCount = bounty._count?.submissions ?? 0;
   const maxParticipants = null;
@@ -232,8 +232,7 @@ export function BountyCard({
             {bounty.type === "MULTI_WINNER_MILESTONE" && (
               <Badge className="bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 text-xs px-2.5 py-1 flex items-center gap-1">
                 <Users className="size-3" />
-                {cardBounty.totalSlotsOccupied ?? 0} /{" "}
-                {cardBounty.maxSlots ?? 5} slots
+                {bounty.totalSlotsOccupied ?? 0} / {bounty.maxSlots ?? 5} slots
               </Badge>
             )}
           </div>

--- a/components/bounty/bounty-card.tsx
+++ b/components/bounty/bounty-card.tsx
@@ -13,14 +13,18 @@ import { Clock, Users, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { BountyFieldsFragment } from "@/lib/graphql/generated";
-import type { Bounty } from "@/types/bounty";
 import { EscrowStatus } from "./escrow-status";
 import { useEscrowPool } from "@/hooks/use-escrow";
 import { getRoundPhase } from "@/hooks/use-lightning-rounds";
 import { BookmarkButton } from "./bookmark-button";
 
+type CardBounty = BountyFieldsFragment & {
+  totalSlotsOccupied?: number | null;
+  maxSlots?: number | null;
+};
+
 interface BountyCardProps {
-  bounty: BountyFieldsFragment;
+  bounty: CardBounty;
   onClick?: () => void;
   variant?: "grid" | "list";
 }
@@ -229,7 +233,7 @@ export function BountyCard({
             {bounty.type === "MULTI_WINNER_MILESTONE" && (
               <Badge className="bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 text-xs px-2.5 py-1 flex items-center gap-1">
                 <Users className="size-3" />
-                {(bounty as unknown as Bounty).totalSlotsOccupied ?? 0} / {(bounty as unknown as Bounty).maxSlots ?? 5} slots
+                {bounty.totalSlotsOccupied ?? 0} / {bounty.maxSlots ?? 5} slots
               </Badge>
             )}
           </div>

--- a/components/bounty/bounty-card.tsx
+++ b/components/bounty/bounty-card.tsx
@@ -13,18 +13,16 @@ import { Clock, Users, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { BountyFieldsFragment } from "@/lib/graphql/generated";
+import type { Bounty } from "@/types/bounty";
 import { EscrowStatus } from "./escrow-status";
 import { useEscrowPool } from "@/hooks/use-escrow";
 import { getRoundPhase } from "@/hooks/use-lightning-rounds";
 import { BookmarkButton } from "./bookmark-button";
 
-type CardBounty = BountyFieldsFragment & {
-  totalSlotsOccupied?: number | null;
-  maxSlots?: number | null;
-};
+type CardBounty = BountyFieldsFragment & Partial<Bounty>;
 
 interface BountyCardProps {
-  bounty: CardBounty;
+  bounty: BountyFieldsFragment;
   onClick?: () => void;
   variant?: "grid" | "list";
 }
@@ -97,6 +95,7 @@ export function BountyCard({
   const isFcfsClaimed =
     bounty.type === "FIXED_PRICE" && normalizedStatus === "IN_PROGRESS";
   const isCompetition = bounty.type === "COMPETITION";
+  const cardBounty = bounty as CardBounty;
   // claimCount and maxParticipants are pending backend schema fields; use safe fallbacks.
   const slotCount = bounty._count?.submissions ?? 0;
   const maxParticipants = null;
@@ -233,7 +232,8 @@ export function BountyCard({
             {bounty.type === "MULTI_WINNER_MILESTONE" && (
               <Badge className="bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 text-xs px-2.5 py-1 flex items-center gap-1">
                 <Users className="size-3" />
-                {bounty.totalSlotsOccupied ?? 0} / {bounty.maxSlots ?? 5} slots
+                {cardBounty.totalSlotsOccupied ?? 0} /{" "}
+                {cardBounty.maxSlots ?? 5} slots
               </Badge>
             )}
           </div>


### PR DESCRIPTION
Closes #273

refactor(bounty-card): remove unsafe Bounty casts for slot counts

Replace the ad-hoc `(bounty as unknown as Bounty)` casts with a dedicated
`CardBounty` type that extends `BountyFieldsFragment` with the optional
`totalSlotsOccupied` and `maxSlots` fields.

Changes:
- Introduce `CardBounty` for `BountyCardProps`
- Remove unsafe casts when reading slot count values
- Remove unused `Bounty` import
- Preserve type safety without relying on `Partial<Bounty>`

Validation:
- `npx tsc --noEmit` passes
- `npx eslint components/bounty/bounty-card.tsx` passes with no warnings
- No remaining `(bounty as unknown as Bounty)` or object-literal casts in
  `components/bounty/` (except the existing `session?.user` casts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the bounty card’s slot count display so milestone badges show the correct occupied and total slots, with safer fallback values when data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->