### PR TITLE
test(e2e): add Playwright coverage for Raise Dispute flow

### DIFF
--- a/e2e/bounty-application.spec.ts
+++ b/e2e/bounty-application.spec.ts
@@ -16,7 +16,12 @@
  */
 
 import { test, expect, type Page } from "@playwright/test";
-import { stubAuth, seedSessionCookie } from "./helpers/mocks";
+import {
+  makeSession,
+  stubAuth,
+  seedSessionCookie,
+  LEADERBOARD_STUBS,
+} from "./helpers/mocks";
 
 // Must be a valid UUID (all hex chars) so toBountyIdBigInt() in
 // use-competition-bounty.ts can parse it without throwing ContestError("tx_failed").
@@ -105,16 +110,11 @@ const MOCK_BOUNTY_FRAGMENT = {
 };
 
 // Session includes walletAddress so handleJoin() passes the wallet guard.
-const MOCK_SESSION = {
-  user: {
-    id: "user-e2e-tester",
-    name: "E2E Tester",
-    email: "e2e@test.com",
-    image: null,
-    walletAddress: "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGYWDOUALPIF5JD4PI21JQ",
-  },
-  session: { token: "fake-e2e-token" },
-};
+const MOCK_SESSION = makeSession(
+  "user-e2e-tester",
+  "E2E Tester",
+  "e2e@test.com",
+);
 
 type ContestContracts = {
   claimBounty: (args: {
@@ -165,65 +165,55 @@ export async function setupMocks(page: Page) {
       /* ignore */
     }
 
-    switch (body.operationName) {
-      case "Bounties":
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            data: {
-              bounties: {
-                bounties: [
-                  MOCK_BOUNTY_FRAGMENT,
-                  MOCK_MULTI_WINNER_BOUNTY_FRAGMENT,
-                ],
-                total: 2,
-                limit: 20,
-                offset: 0,
-              },
+    const op = body.operationName ?? "";
+
+    if (op === "Bounties") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            bounties: {
+              bounties: [
+                MOCK_BOUNTY_FRAGMENT,
+                MOCK_MULTI_WINNER_BOUNTY_FRAGMENT,
+              ],
+              total: 2,
+              limit: 20,
+              offset: 0,
             },
-          }),
-        });
-        return;
-      case "Bounty": {
-        const requestedId = body.variables?.id;
-        const bountyData =
-          requestedId === BOUNTY_ID_MULTI
-            ? MOCK_MULTI_WINNER_BOUNTY_FRAGMENT
-            : MOCK_BOUNTY_FRAGMENT;
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            data: { bounty: { ...bountyData, submissions: [] } },
-          }),
-        });
-        return;
-      }
-      case "TopContributors":
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: { topContributors: [] } }),
-        });
-        return;
-      case "Leaderboard":
-      case "GetLeaderboardUser":
-      case "LeaderboardUser":
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            data: {
-              leaderboard: { contributors: [], total: 0, limit: 10, offset: 0 },
-              userLeaderboard: null,
-            },
-          }),
-        });
-        return;
-      default:
-        await route.abort("failed");
+          },
+        }),
+      });
+      return;
     }
+
+    if (op === "Bounty") {
+      const requestedId = body.variables?.id;
+      const bountyData =
+        requestedId === BOUNTY_ID_MULTI
+          ? MOCK_MULTI_WINNER_BOUNTY_FRAGMENT
+          : MOCK_BOUNTY_FRAGMENT;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: { bounty: { ...bountyData, submissions: [] } },
+        }),
+      });
+      return;
+    }
+
+    if (op in LEADERBOARD_STUBS) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: LEADERBOARD_STUBS[op] }),
+      });
+      return;
+    }
+
+    await route.abort("failed");
   });
 
   await seedSessionCookie(page);

--- a/e2e/bounty-application.spec.ts
+++ b/e2e/bounty-application.spec.ts
@@ -16,11 +16,7 @@
  */
 
 import { test, expect, type Page } from "@playwright/test";
-import {
-  stubAuth,
-  seedSessionCookie,
-  LEADERBOARD_STUBS,
-} from "./helpers/mocks";
+import { stubAuth, seedSessionCookie } from "./helpers/mocks";
 
 // Must be a valid UUID (all hex chars) so toBountyIdBigInt() in
 // use-competition-bounty.ts can parse it without throwing ContestError("tx_failed").

--- a/e2e/bounty-application.spec.ts
+++ b/e2e/bounty-application.spec.ts
@@ -16,6 +16,11 @@
  */
 
 import { test, expect, type Page } from "@playwright/test";
+import {
+  stubAuth,
+  seedSessionCookie,
+  LEADERBOARD_STUBS,
+} from "./helpers/mocks";
 
 // Must be a valid UUID (all hex chars) so toBountyIdBigInt() in
 // use-competition-bounty.ts can parse it without throwing ContestError("tx_failed").
@@ -122,7 +127,7 @@ type ContestContracts = {
   }) => Promise<{ txHash: string }>;
 };
 
-async function setupMocks(page: Page) {
+export async function setupMocks(page: Page) {
   // Inject successful contract client by default
   await page.addInitScript(() => {
     (globalThis as { __claimBountyCalls?: number }).__claimBountyCalls = 0;
@@ -148,27 +153,7 @@ async function setupMocks(page: Page) {
     };
   });
 
-  await page.route("**/api/auth/**", async (route) => {
-    const url = new URL(route.request().url());
-    // better-auth's getSession endpoint is `/api/auth/get-session` — match
-    // both shapes so the session mock catches it.
-    if (
-      url.pathname.endsWith("/get-session") ||
-      url.pathname.endsWith("/session")
-    ) {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(MOCK_SESSION),
-      });
-    } else {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: "{}",
-      });
-    }
-  });
+  await stubAuth(page, MOCK_SESSION);
 
   await page.route("**/api/graphql", async (route) => {
     let body: {
@@ -245,17 +230,7 @@ async function setupMocks(page: Page) {
     }
   });
 
-  await page.context().addCookies([
-    {
-      name: "boundless_auth.session_token",
-      value: "fake-e2e-token",
-      domain: "localhost",
-      path: "/",
-      httpOnly: false,
-      secure: false,
-      sameSite: "Lax",
-    },
-  ]);
+  await seedSessionCookie(page);
 }
 
 test.describe("Bounty application flow", () => {

--- a/e2e/helpers/mocks.ts
+++ b/e2e/helpers/mocks.ts
@@ -12,11 +12,22 @@ import type { Page } from "@playwright/test";
 export const WALLET_ADDRESS =
   "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGYWDOUALPIF5JD4PI21JQ";
 
+export interface MockSession {
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    image: string | null;
+    walletAddress: string;
+  };
+  session: { token: string };
+}
+
 export function makeSession(
   userId: string,
   name: string,
   email: string,
-): object {
+): MockSession {
   return {
     user: {
       id: userId,

--- a/e2e/helpers/mocks.ts
+++ b/e2e/helpers/mocks.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared e2e mock helpers.
+ *
+ * Provides the baseline auth + GraphQL route stubs used across spec files.
+ * Each spec can register additional page.route() calls *after* calling these
+ * helpers to override specific operations (Playwright matches the first
+ * registered handler that accepts the request).
+ */
+
+import type { Page } from "@playwright/test";
+
+export const WALLET_ADDRESS =
+  "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGYWDOUALPIF5JD4PI21JQ";
+
+export function makeSession(
+  userId: string,
+  name: string,
+  email: string,
+): object {
+  return {
+    user: {
+      id: userId,
+      name,
+      email,
+      image: null,
+      walletAddress: WALLET_ADDRESS,
+    },
+    session: { token: "fake-e2e-token" },
+  };
+}
+
+/** Stub all /api/auth/** routes to return the given session object. */
+export async function stubAuth(page: Page, session: object): Promise<void> {
+  await page.route("**/api/auth/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      url.pathname.endsWith("/get-session") ||
+      url.pathname.endsWith("/session")
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(session),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    }
+  });
+}
+
+/**
+ * Stub /api/graphql for a specific set of operations.
+ * Pass a map of operationName → response data; any unmatched operation is aborted.
+ */
+export async function stubGraphQL(
+  page: Page,
+  handlers: Record<string, unknown>,
+): Promise<void> {
+  await page.route("**/api/graphql", async (route) => {
+    let body: { operationName?: string } = {};
+    try {
+      body = JSON.parse(route.request().postData() ?? "{}") as {
+        operationName?: string;
+      };
+    } catch {
+      /* ignore */
+    }
+    const op = body.operationName ?? "";
+    if (op in handlers) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: handlers[op] }),
+      });
+    } else {
+      await route.abort("failed");
+    }
+  });
+}
+
+/** Returns the hostname from BASE_URL (or 'localhost' as fallback). */
+export function baseUrlHostname(): string {
+  return new URL(process.env.BASE_URL ?? "http://localhost:3000").hostname;
+}
+
+/** Seed the session cookie against the correct host. */
+export async function seedSessionCookie(page: Page): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: "boundless_auth.session_token",
+      value: "fake-e2e-token",
+      domain: baseUrlHostname(),
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+/** Null-response stubs for leaderboard operations that every detail page queries. */
+export const LEADERBOARD_STUBS: Record<string, unknown> = {
+  TopContributors: {},
+  Leaderboard: {},
+  GetLeaderboardUser: {},
+  LeaderboardUser: {},
+};

--- a/e2e/raise-dispute.spec.ts
+++ b/e2e/raise-dispute.spec.ts
@@ -2,7 +2,8 @@
  * E2E: Raise Dispute Flow
  *
  * Covers the full Raise Dispute journey on a bounty detail page:
- *   1. Eligible user sees an active Raise Dispute button
+ *   1. Eligible users (creator / submitter) on IN_PROGRESS or UNDER_REVIEW bounties
+ *      see an active Raise Dispute button
  *   2. Clicking it opens the AlertDialog with reason Select and description Textarea
  *   3. Submitting with empty fields keeps dialog open and shows inline validation
  *   4. Valid submission closes dialog, shows success toast, redirects to /dispute/:id
@@ -10,123 +11,109 @@
  *
  * Stability strategy:
  *   - GraphQL intercepted via page.route() – hermetic, no live backend.
- *   - POST /api/disputes mocked via page.route().
- *   - Reuses MOCK_SESSION and setupMocks pattern from bounty-application.spec.ts.
- *   - Selectors use roles/labels/visible text only.
+ *   - POST /api/disputes mocked via page.route(); request contract (method + body)
+ *     is asserted on the success path.
+ *   - Reuses stubAuth / seedSessionCookie from e2e/helpers/mocks.ts.
+ *   - Selectors use roles and visible labels only.
  *   - Timing via await expect(...) – no arbitrary sleeps.
  */
 
 import { test, expect, type Page } from "@playwright/test";
+import {
+  makeSession,
+  stubAuth,
+  seedSessionCookie,
+  LEADERBOARD_STUBS,
+} from "./helpers/mocks";
 
 const BOUNTY_ID = "e2ec0bcd-dead-beef-cafe-ab01cd02ef06";
 const CREATOR_ID = "user-dispute-creator";
 const CONTRIBUTOR_ID = "user-dispute-contributor";
 const NEW_DISPUTE_ID = "dispute-abc-123";
-const WALLET_ADDRESS =
-  "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGYWDOUALPIF5JD4PI21JQ";
 
-// Bounty in IN_PROGRESS with one submission by the contributor
-const MOCK_BOUNTY = {
-  __typename: "Bounty",
-  id: BOUNTY_ID,
-  title: "Implement ZKP Dispute Test Bounty",
-  description: "A bounty used for dispute e2e tests.",
-  status: "IN_PROGRESS",
-  type: "MILESTONE_BASED",
-  rewardAmount: 500,
-  rewardCurrency: "XLM",
-  createdAt: "2025-01-10T09:00:00Z",
-  updatedAt: "2025-01-24T14:20:00Z",
-  organizationId: "org-test",
-  projectId: null,
-  bountyWindowId: null,
-  githubIssueUrl: "https://github.com/test/repo/issues/99",
-  githubIssueNumber: 99,
-  createdBy: CREATOR_ID,
-  organization: {
-    __typename: "BountyOrganization",
-    id: "org-test",
-    name: "Test Org",
-    logo: null,
-    slug: "test-org",
-  },
-  project: null,
-  bountyWindow: null,
-  _count: { __typename: "BountyCount", submissions: 1 },
-  submissions: [
-    {
-      __typename: "BountySubmissionType",
-      id: "sub-dispute-001",
-      bountyId: BOUNTY_ID,
-      submittedBy: CONTRIBUTOR_ID,
-      githubPullRequestUrl: "https://github.com/test/repo/pull/10",
-      status: "PENDING",
-      reviewComments: null,
-      reviewedAt: null,
-      reviewedBy: null,
-      paidAt: null,
-      rewardTransactionHash: null,
-      createdAt: "2025-01-20T10:00:00Z",
-      updatedAt: "2025-01-20T10:00:00Z",
-      submittedByUser: {
-        __typename: "BountySubmissionUser",
-        id: CONTRIBUTOR_ID,
-        name: "Test Contributor",
-        image: null,
-      },
-      reviewedByUser: null,
-    },
-  ],
-  milestones: [{ id: "m1", title: "Milestone 1", isCompleted: false }],
-  contributorProgress: null,
-  maxSlots: null,
-  totalSlotsOccupied: null,
-};
-
-function makeMockSession(userId: string) {
+function makeBounty(status: "IN_PROGRESS" | "UNDER_REVIEW") {
   return {
-    user: {
-      id: userId,
-      name: userId === CREATOR_ID ? "Test Creator" : "Test Contributor",
-      email: `${userId}@test.com`,
-      image: null,
-      walletAddress: WALLET_ADDRESS,
+    __typename: "Bounty",
+    id: BOUNTY_ID,
+    title: "Implement ZKP Dispute Test Bounty",
+    description: "A bounty used for dispute e2e tests.",
+    status,
+    type: "MILESTONE_BASED",
+    rewardAmount: 500,
+    rewardCurrency: "XLM",
+    createdAt: "2025-01-10T09:00:00Z",
+    updatedAt: "2025-01-24T14:20:00Z",
+    organizationId: "org-test",
+    projectId: null,
+    bountyWindowId: null,
+    githubIssueUrl: "https://github.com/test/repo/issues/99",
+    githubIssueNumber: 99,
+    createdBy: CREATOR_ID,
+    organization: {
+      __typename: "BountyOrganization",
+      id: "org-test",
+      name: "Test Org",
+      logo: null,
+      slug: "test-org",
     },
-    session: { token: "fake-e2e-token" },
+    project: null,
+    bountyWindow: null,
+    _count: { __typename: "BountyCount", submissions: 1 },
+    submissions: [
+      {
+        __typename: "BountySubmissionType",
+        id: "sub-dispute-001",
+        bountyId: BOUNTY_ID,
+        submittedBy: CONTRIBUTOR_ID,
+        githubPullRequestUrl: "https://github.com/test/repo/pull/10",
+        status: "PENDING",
+        reviewComments: null,
+        reviewedAt: null,
+        reviewedBy: null,
+        paidAt: null,
+        rewardTransactionHash: null,
+        createdAt: "2025-01-20T10:00:00Z",
+        updatedAt: "2025-01-20T10:00:00Z",
+        submittedByUser: {
+          __typename: "BountySubmissionUser",
+          id: CONTRIBUTOR_ID,
+          name: "Test Contributor",
+          image: null,
+        },
+        reviewedByUser: null,
+      },
+    ],
+    milestones: [{ id: "m1", title: "Milestone 1", isCompleted: false }],
+    contributorProgress: null,
+    maxSlots: null,
+    totalSlotsOccupied: null,
   };
 }
+
+const MOCK_BOUNTY = makeBounty("IN_PROGRESS");
+const MOCK_BOUNTY_UNDER_REVIEW = makeBounty("UNDER_REVIEW");
+
+type DisputeHandler = (
+  route: Parameters<Parameters<Page["route"]>[1]>[0],
+) => Promise<void>;
 
 async function setupMocks(
   page: Page,
   options: {
     userId: string;
-    bountyData?: typeof MOCK_BOUNTY;
-    disputeHandler?: (
-      route: Parameters<Parameters<Page["route"]>[1]>[0],
-    ) => Promise<void>;
+    bountyData?: ReturnType<typeof makeBounty>;
+    disputeHandler?: DisputeHandler;
   },
 ) {
   const { userId, bountyData = MOCK_BOUNTY, disputeHandler } = options;
 
-  await page.route("**/api/auth/**", async (route) => {
-    const url = new URL(route.request().url());
-    if (
-      url.pathname.endsWith("/get-session") ||
-      url.pathname.endsWith("/session")
-    ) {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(makeMockSession(userId)),
-      });
-    } else {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: "{}",
-      });
-    }
-  });
+  const session = makeSession(
+    userId,
+    userId === CREATOR_ID ? "Test Creator" : "Test Contributor",
+    `${userId}@test.com`,
+  );
+
+  await stubAuth(page, session);
 
   await page.route("**/api/graphql", async (route) => {
     let body: { operationName?: string } = {};
@@ -137,31 +124,26 @@ async function setupMocks(
     } catch {
       /* ignore */
     }
-
-    switch (body.operationName) {
-      case "Bounty":
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: { bounty: bountyData } }),
-        });
-        return;
-      case "TopContributors":
-      case "Leaderboard":
-      case "GetLeaderboardUser":
-      case "LeaderboardUser":
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: {} }),
-        });
-        return;
-      default:
-        await route.abort("failed");
+    const op = body.operationName ?? "";
+    if (op in LEADERBOARD_STUBS) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: LEADERBOARD_STUBS[op] }),
+      });
+      return;
     }
+    if (op === "Bounty") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { bounty: bountyData } }),
+      });
+      return;
+    }
+    await route.abort("failed");
   });
 
-  // Default: successful dispute creation
   await page.route("**/api/disputes", async (route) => {
     if (disputeHandler) {
       await disputeHandler(route);
@@ -174,17 +156,7 @@ async function setupMocks(
     }
   });
 
-  await page.context().addCookies([
-    {
-      name: "boundless_auth.session_token",
-      value: "fake-e2e-token",
-      domain: "localhost",
-      path: "/",
-      httpOnly: false,
-      secure: false,
-      sameSite: "Lax",
-    },
-  ]);
+  await seedSessionCookie(page);
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -200,7 +172,7 @@ async function openDisputeDialog(page: Page) {
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 test.describe("Raise Dispute flow", () => {
-  // ── 1. Eligible user sees the Raise Dispute button ──────────────────────
+  // ── 1. Button visibility: IN_PROGRESS ────────────────────────────────────
 
   test("creator on IN_PROGRESS bounty sees an active Raise Dispute button", async ({
     page,
@@ -222,7 +194,35 @@ test.describe("Raise Dispute flow", () => {
     await expect(btn).toBeEnabled();
   });
 
-  // ── 2. Dialog opens with correct form elements ──────────────────────────
+  // ── 2. Button visibility: UNDER_REVIEW ───────────────────────────────────
+
+  test("creator on UNDER_REVIEW bounty sees an active Raise Dispute button", async ({
+    page,
+  }) => {
+    await setupMocks(page, {
+      userId: CREATOR_ID,
+      bountyData: MOCK_BOUNTY_UNDER_REVIEW,
+    });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    const btn = page.getByRole("button", { name: /Raise a Dispute/i });
+    await expect(btn).toBeVisible({ timeout: 10_000 });
+    await expect(btn).toBeEnabled();
+  });
+
+  test("participant (submitter) on UNDER_REVIEW bounty sees an active Raise Dispute button", async ({
+    page,
+  }) => {
+    await setupMocks(page, {
+      userId: CONTRIBUTOR_ID,
+      bountyData: MOCK_BOUNTY_UNDER_REVIEW,
+    });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    const btn = page.getByRole("button", { name: /Raise a Dispute/i });
+    await expect(btn).toBeVisible({ timeout: 10_000 });
+    await expect(btn).toBeEnabled();
+  });
+
+  // ── 3. Dialog opens with correct form elements ──────────────────────────
 
   test("clicking Raise Dispute opens the AlertDialog with Select and Textarea", async ({
     page,
@@ -242,7 +242,7 @@ test.describe("Raise Dispute flow", () => {
     await expect(page.getByRole("button", { name: /Cancel/i })).toBeVisible();
   });
 
-  // ── 3. Validation: empty fields keep dialog open ────────────────────────
+  // ── 4. Validation: empty fields keep dialog open ────────────────────────
 
   test("submitting with empty reason and empty description shows inline validation errors", async ({
     page,
@@ -257,7 +257,6 @@ test.describe("Raise Dispute flow", () => {
       timeout: 5_000,
     });
     await expect(page.getByText(/Please describe the dispute/i)).toBeVisible();
-    // Dialog must stay open
     await expect(page.getByRole("alertdialog")).toBeVisible();
   });
 
@@ -268,7 +267,6 @@ test.describe("Raise Dispute flow", () => {
     await page.goto(`/bounty/${BOUNTY_ID}`);
     await openDisputeDialog(page);
 
-    // Pick any reason from the Select
     await page.getByRole("combobox").click();
     await page.getByRole("option").first().click();
 
@@ -280,25 +278,51 @@ test.describe("Raise Dispute flow", () => {
     await expect(page.getByRole("alertdialog")).toBeVisible();
   });
 
-  // ── 4. Successful submission ────────────────────────────────────────────
+  // ── 5. Successful submission ────────────────────────────────────────────
 
-  test("valid submission closes dialog, shows success toast, and redirects to /dispute/:id", async ({
+  test("valid submission sends correct POST body, closes dialog, shows success toast, and redirects to /dispute/:id", async ({
     page,
   }) => {
-    await setupMocks(page, { userId: CREATOR_ID });
+    const capturedRequests: { method: string; body: unknown }[] = [];
+
+    await setupMocks(page, {
+      userId: CREATOR_ID,
+      disputeHandler: async (route) => {
+        capturedRequests.push({
+          method: route.request().method(),
+          body: JSON.parse(route.request().postData() ?? "{}") as unknown,
+        });
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({ id: NEW_DISPUTE_ID, campaignId: BOUNTY_ID }),
+        });
+      },
+    });
+
     await page.goto(`/bounty/${BOUNTY_ID}`);
     await openDisputeDialog(page);
 
-    // Select a reason
     await page.getByRole("combobox").click();
     await page.getByRole("option").first().click();
-
-    // Fill description
     await page
       .getByLabel(/Description/i)
       .fill("The milestone was not delivered on time.");
 
     await page.getByRole("button", { name: /Submit Dispute/i }).click();
+
+    // Assert request contract: method must be POST and body must include the
+    // three required fields.
+    await expect
+      .poll(() => capturedRequests.length, { timeout: 10_000 })
+      .toBeGreaterThan(0);
+    const req = capturedRequests[0]!;
+    expect(req.method).toBe("POST");
+    expect(req.body).toMatchObject({
+      campaignId: BOUNTY_ID,
+      reason: expect.any(String),
+      description: expect.any(String),
+    });
 
     // Dialog closes
     await expect(page.getByRole("alertdialog")).not.toBeVisible({
@@ -316,7 +340,7 @@ test.describe("Raise Dispute flow", () => {
     });
   });
 
-  // ── 5. API failure keeps dialog open and shows error toast ───────────────
+  // ── 6. API failure keeps dialog open and shows error toast ───────────────
 
   test("API 500 keeps dialog open and shows error toast", async ({ page }) => {
     await setupMocks(page, {
@@ -332,23 +356,17 @@ test.describe("Raise Dispute flow", () => {
     await page.goto(`/bounty/${BOUNTY_ID}`);
     await openDisputeDialog(page);
 
-    // Select a reason
     await page.getByRole("combobox").click();
     await page.getByRole("option").first().click();
-
-    // Fill description
     await page
       .getByLabel(/Description/i)
       .fill("Something went wrong on your side.");
 
     await page.getByRole("button", { name: /Submit Dispute/i }).click();
 
-    // Error toast
     await expect(page.getByText(/Failed to file dispute/i)).toBeVisible({
       timeout: 10_000,
     });
-
-    // Dialog must remain open
     await expect(page.getByRole("alertdialog")).toBeVisible();
   });
 });

--- a/e2e/raise-dispute.spec.ts
+++ b/e2e/raise-dispute.spec.ts
@@ -1,0 +1,354 @@
+/**
+ * E2E: Raise Dispute Flow
+ *
+ * Covers the full Raise Dispute journey on a bounty detail page:
+ *   1. Eligible user sees an active Raise Dispute button
+ *   2. Clicking it opens the AlertDialog with reason Select and description Textarea
+ *   3. Submitting with empty fields keeps dialog open and shows inline validation
+ *   4. Valid submission closes dialog, shows success toast, redirects to /dispute/:id
+ *   5. API 500 keeps dialog open and shows error toast
+ *
+ * Stability strategy:
+ *   - GraphQL intercepted via page.route() – hermetic, no live backend.
+ *   - POST /api/disputes mocked via page.route().
+ *   - Reuses MOCK_SESSION and setupMocks pattern from bounty-application.spec.ts.
+ *   - Selectors use roles/labels/visible text only.
+ *   - Timing via await expect(...) – no arbitrary sleeps.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const BOUNTY_ID = "e2ec0bcd-dead-beef-cafe-ab01cd02ef06";
+const CREATOR_ID = "user-dispute-creator";
+const CONTRIBUTOR_ID = "user-dispute-contributor";
+const NEW_DISPUTE_ID = "dispute-abc-123";
+const WALLET_ADDRESS =
+  "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGYWDOUALPIF5JD4PI21JQ";
+
+// Bounty in IN_PROGRESS with one submission by the contributor
+const MOCK_BOUNTY = {
+  __typename: "Bounty",
+  id: BOUNTY_ID,
+  title: "Implement ZKP Dispute Test Bounty",
+  description: "A bounty used for dispute e2e tests.",
+  status: "IN_PROGRESS",
+  type: "MILESTONE_BASED",
+  rewardAmount: 500,
+  rewardCurrency: "XLM",
+  createdAt: "2025-01-10T09:00:00Z",
+  updatedAt: "2025-01-24T14:20:00Z",
+  organizationId: "org-test",
+  projectId: null,
+  bountyWindowId: null,
+  githubIssueUrl: "https://github.com/test/repo/issues/99",
+  githubIssueNumber: 99,
+  createdBy: CREATOR_ID,
+  organization: {
+    __typename: "BountyOrganization",
+    id: "org-test",
+    name: "Test Org",
+    logo: null,
+    slug: "test-org",
+  },
+  project: null,
+  bountyWindow: null,
+  _count: { __typename: "BountyCount", submissions: 1 },
+  submissions: [
+    {
+      __typename: "BountySubmissionType",
+      id: "sub-dispute-001",
+      bountyId: BOUNTY_ID,
+      submittedBy: CONTRIBUTOR_ID,
+      githubPullRequestUrl: "https://github.com/test/repo/pull/10",
+      status: "PENDING",
+      reviewComments: null,
+      reviewedAt: null,
+      reviewedBy: null,
+      paidAt: null,
+      rewardTransactionHash: null,
+      createdAt: "2025-01-20T10:00:00Z",
+      updatedAt: "2025-01-20T10:00:00Z",
+      submittedByUser: {
+        __typename: "BountySubmissionUser",
+        id: CONTRIBUTOR_ID,
+        name: "Test Contributor",
+        image: null,
+      },
+      reviewedByUser: null,
+    },
+  ],
+  milestones: [{ id: "m1", title: "Milestone 1", isCompleted: false }],
+  contributorProgress: null,
+  maxSlots: null,
+  totalSlotsOccupied: null,
+};
+
+function makeMockSession(userId: string) {
+  return {
+    user: {
+      id: userId,
+      name: userId === CREATOR_ID ? "Test Creator" : "Test Contributor",
+      email: `${userId}@test.com`,
+      image: null,
+      walletAddress: WALLET_ADDRESS,
+    },
+    session: { token: "fake-e2e-token" },
+  };
+}
+
+async function setupMocks(
+  page: Page,
+  options: {
+    userId: string;
+    bountyData?: typeof MOCK_BOUNTY;
+    disputeHandler?: (
+      route: Parameters<Parameters<Page["route"]>[1]>[0],
+    ) => Promise<void>;
+  },
+) {
+  const { userId, bountyData = MOCK_BOUNTY, disputeHandler } = options;
+
+  await page.route("**/api/auth/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      url.pathname.endsWith("/get-session") ||
+      url.pathname.endsWith("/session")
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeMockSession(userId)),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      });
+    }
+  });
+
+  await page.route("**/api/graphql", async (route) => {
+    let body: { operationName?: string } = {};
+    try {
+      body = JSON.parse(route.request().postData() ?? "{}") as {
+        operationName?: string;
+      };
+    } catch {
+      /* ignore */
+    }
+
+    switch (body.operationName) {
+      case "Bounty":
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: { bounty: bountyData } }),
+        });
+        return;
+      case "TopContributors":
+      case "Leaderboard":
+      case "GetLeaderboardUser":
+      case "LeaderboardUser":
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: {} }),
+        });
+        return;
+      default:
+        await route.abort("failed");
+    }
+  });
+
+  // Default: successful dispute creation
+  await page.route("**/api/disputes", async (route) => {
+    if (disputeHandler) {
+      await disputeHandler(route);
+    } else {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ id: NEW_DISPUTE_ID, campaignId: BOUNTY_ID }),
+      });
+    }
+  });
+
+  await page.context().addCookies([
+    {
+      name: "boundless_auth.session_token",
+      value: "fake-e2e-token",
+      domain: "localhost",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function openDisputeDialog(page: Page) {
+  const raiseBtn = page.getByRole("button", { name: /Raise a Dispute/i });
+  await expect(raiseBtn).toBeVisible({ timeout: 10_000 });
+  await expect(raiseBtn).toBeEnabled();
+  await raiseBtn.click();
+  await expect(page.getByRole("alertdialog")).toBeVisible({ timeout: 5_000 });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test.describe("Raise Dispute flow", () => {
+  // ── 1. Eligible user sees the Raise Dispute button ──────────────────────
+
+  test("creator on IN_PROGRESS bounty sees an active Raise Dispute button", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    const btn = page.getByRole("button", { name: /Raise a Dispute/i });
+    await expect(btn).toBeVisible({ timeout: 10_000 });
+    await expect(btn).toBeEnabled();
+  });
+
+  test("participant (submitter) on IN_PROGRESS bounty sees an active Raise Dispute button", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CONTRIBUTOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    const btn = page.getByRole("button", { name: /Raise a Dispute/i });
+    await expect(btn).toBeVisible({ timeout: 10_000 });
+    await expect(btn).toBeEnabled();
+  });
+
+  // ── 2. Dialog opens with correct form elements ──────────────────────────
+
+  test("clicking Raise Dispute opens the AlertDialog with Select and Textarea", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await openDisputeDialog(page);
+
+    await expect(page.getByRole("alertdialog")).toContainText(
+      "Raise a Dispute",
+    );
+    await expect(page.getByLabel(/Reason/i)).toBeVisible();
+    await expect(page.getByLabel(/Description/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Submit Dispute/i }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /Cancel/i })).toBeVisible();
+  });
+
+  // ── 3. Validation: empty fields keep dialog open ────────────────────────
+
+  test("submitting with empty reason and empty description shows inline validation errors", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await openDisputeDialog(page);
+
+    await page.getByRole("button", { name: /Submit Dispute/i }).click();
+
+    await expect(page.getByText(/Please select a reason/i)).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByText(/Please describe the dispute/i)).toBeVisible();
+    // Dialog must stay open
+    await expect(page.getByRole("alertdialog")).toBeVisible();
+  });
+
+  test("submitting with a reason but empty description keeps dialog open with description error", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await openDisputeDialog(page);
+
+    // Pick any reason from the Select
+    await page.getByRole("combobox").click();
+    await page.getByRole("option").first().click();
+
+    await page.getByRole("button", { name: /Submit Dispute/i }).click();
+
+    await expect(page.getByText(/Please describe the dispute/i)).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByRole("alertdialog")).toBeVisible();
+  });
+
+  // ── 4. Successful submission ────────────────────────────────────────────
+
+  test("valid submission closes dialog, shows success toast, and redirects to /dispute/:id", async ({
+    page,
+  }) => {
+    await setupMocks(page, { userId: CREATOR_ID });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await openDisputeDialog(page);
+
+    // Select a reason
+    await page.getByRole("combobox").click();
+    await page.getByRole("option").first().click();
+
+    // Fill description
+    await page
+      .getByLabel(/Description/i)
+      .fill("The milestone was not delivered on time.");
+
+    await page.getByRole("button", { name: /Submit Dispute/i }).click();
+
+    // Dialog closes
+    await expect(page.getByRole("alertdialog")).not.toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Success toast
+    await expect(page.getByText(/Dispute filed successfully/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Redirect to /dispute/<id>
+    await expect(page).toHaveURL(`/dispute/${NEW_DISPUTE_ID}`, {
+      timeout: 10_000,
+    });
+  });
+
+  // ── 5. API failure keeps dialog open and shows error toast ───────────────
+
+  test("API 500 keeps dialog open and shows error toast", async ({ page }) => {
+    await setupMocks(page, {
+      userId: CREATOR_ID,
+      disputeHandler: async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Internal Server Error" }),
+        });
+      },
+    });
+    await page.goto(`/bounty/${BOUNTY_ID}`);
+    await openDisputeDialog(page);
+
+    // Select a reason
+    await page.getByRole("combobox").click();
+    await page.getByRole("option").first().click();
+
+    // Fill description
+    await page
+      .getByLabel(/Description/i)
+      .fill("Something went wrong on your side.");
+
+    await page.getByRole("button", { name: /Submit Dispute/i }).click();
+
+    // Error toast
+    await expect(page.getByText(/Failed to file dispute/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Dialog must remain open
+    await expect(page.getByRole("alertdialog")).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   reporter: process.env.CI ? "github" : "html",
   outputDir: "./test-results",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     navigationTimeout: 60_000,
@@ -22,12 +22,12 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.CI ? "pnpm start" : "pnpm run dev",
-    url: "http://localhost:3000",
+    url: process.env.BASE_URL ?? "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: {
-      NEXT_PUBLIC_GRAPHQL_URL: "http://localhost:3000/api/graphql",
-      NEXT_PUBLIC_API_URL: "http://localhost:3000",
+      NEXT_PUBLIC_GRAPHQL_URL: `${process.env.BASE_URL ?? "http://localhost:3000"}/api/graphql`,
+      NEXT_PUBLIC_API_URL: process.env.BASE_URL ?? "http://localhost:3000",
     },
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   reporter: process.env.CI ? "github" : "html",
   outputDir: "./test-results",
   use: {
-    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
+    baseURL: "http://localhost:3000",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     navigationTimeout: 60_000,
@@ -22,12 +22,12 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.CI ? "pnpm start" : "pnpm run dev",
-    url: process.env.BASE_URL ?? "http://localhost:3000",
+    url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: {
-      NEXT_PUBLIC_GRAPHQL_URL: `${process.env.BASE_URL ?? "http://localhost:3000"}/api/graphql`,
-      NEXT_PUBLIC_API_URL: process.env.BASE_URL ?? "http://localhost:3000",
+      NEXT_PUBLIC_GRAPHQL_URL: "http://localhost:3000/api/graphql",
+      NEXT_PUBLIC_API_URL: "http://localhost:3000",
     },
   },
 });


### PR DESCRIPTION
Closes #280

## What

Adds `e2e/raise-dispute.spec.ts` covering the full Raise Dispute flow as specified in #280.

## Tests (7 cases)

1. Creator on an `IN_PROGRESS` bounty sees an active **Raise Dispute** button
2. Participant (submitter) on an `IN_PROGRESS` bounty sees an active **Raise Dispute** button
3. Clicking the button opens the `AlertDialog` with a reason `Select` and description `Textarea`
4. Submitting with empty fields keeps the dialog open and shows inline validation errors
5. Submitting with a reason but empty description keeps the dialog open with a description error
6. Valid submission closes the dialog, shows a success toast, and redirects to `/dispute/:id`
7. API 500 keeps the dialog open and shows an error toast

## Conventions followed

- Reuses `MOCK_SESSION` / `setupMocks` pattern from `e2e/bounty-application.spec.ts`
- `POST /api/disputes` mocked via `page.route('**/api/disputes', ...)`
- No arbitrary sleeps — all timing via `await expect(...)`
- Selectors use roles and visible labels only

## Verified

```
pnpm exec playwright test e2e/raise-dispute.spec.ts
7 passed (1.4m)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Raise a Dispute” flow on bounty detail pages, including clearer handling for validation failures, successful submissions, and server-side errors.
  * Ensured the “Raise a Dispute” button is available and behaves consistently across relevant bounty statuses and user roles.
* **Tests**
  * Added end-to-end coverage for the full “Raise Dispute” journey, including request/response assertions and error handling.
* **Chores**
  * Centralized and reused Playwright authentication and API mocking utilities for more reliable E2E runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->