### PR TITLE
chore: remove debug logging from useSendMessage

### DIFF
--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -702,9 +702,6 @@ export function useSendMessage(bountyId: string) {
         timestamp: new Date().toISOString(),
       });
 
-      console.log(
-        `[useSendMessage] Recorded message for bountyId ${bountyId}: contributorId=${contributorId}, message="${message}"`,
-      );
       return { contributorId, message };
     },
   });


### PR DESCRIPTION
## Remove Leftover Debug Logging from useSendMessage

Closes #294

### Summary

This PR removes a leftover debug `console.log` statement from `useSendMessage` that was logging message content to the browser console.

### Changes

* Removed the debug log from `useSendMessage`
* Preserved the existing mutation behavior and return values
* Kept the `{ contributorId, message }` response unchanged

### Why

The existing log executed on every message submission, which:

* Exposed message content in the browser console
* Added unnecessary noise during development
* Introduced production logging that was no longer needed

### Validation

* No `console.log` statements remain in `useSendMessage`
* Mutation behavior remains unchanged
* Returned values are unchanged
* `pnpm tsc --noEmit`  
* `pnpm lint` (passes with one existing warning in lib/server-graphql.ts)

### Notes

This is a cleanup change only and does not modify application logic or user-facing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused debug log from the messaging flow for a cleaner runtime experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->