### PR TITLE
feat:Replace NEXT_PUBLIC_MOCK_MAINTAINER env flag with useUserRole hook

### DIFF
--- a/components/bounty/bounty-sidebar.tsx
+++ b/components/bounty/bounty-sidebar.tsx
@@ -83,7 +83,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
 
   const handleMarkCompleted = async () => {
     if (!isSponsor) {
-      alert("Only maintainers can mark as completed.");
+      alert("Only sponsors can mark as completed.");
       return;
     }
     setLoading(true);
@@ -114,7 +114,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
       return;
     }
     if (!isSponsor) {
-      alert("Only maintainers can rate contributors.");
+      alert("Only sponsors can rate contributors.");
       return;
     }
     if (!completed) {

--- a/components/bounty/bounty-sidebar.tsx
+++ b/components/bounty/bounty-sidebar.tsx
@@ -252,3 +252,4 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
     </div>
   );
 }
+

--- a/components/bounty/bounty-sidebar.tsx
+++ b/components/bounty/bounty-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { RatingModal } from "../rating/rating-modal";
 import { useClaimBounty } from "@/hooks/use-bounty-mutations";
+import { useUserRole } from "@/hooks/use-user-role";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import type {
@@ -28,17 +29,8 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
   const claimBounty = useClaimBounty();
   const [loading, setLoading] = useState(false);
 
-  // Mock maintainer check for now - in real app this comes from auth context
-  const IS_MAINTAINER = process.env.NEXT_PUBLIC_MOCK_MAINTAINER === "true";
-
-  if (
-    typeof window !== "undefined" &&
-    process.env.NEXT_PUBLIC_MOCK_MAINTAINER === "true"
-  ) {
-    console.warn(
-      "DEV: Mock maintainer enabled in components/bounty/bounty-sidebar.tsx — do NOT enable in production",
-    );
-  }
+  const role = useUserRole();
+  const isSponsor = role === "sponsor";
 
   const createdTimeAgo = useMemo(
     () => formatDistanceToNow(new Date(bounty.createdAt), { addSuffix: true }),
@@ -90,7 +82,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
   } | null>(null);
 
   const handleMarkCompleted = async () => {
-    if (!IS_MAINTAINER) {
+    if (!isSponsor) {
       alert("Only maintainers can mark as completed.");
       return;
     }
@@ -121,7 +113,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
       alert("You have already rated this contributor.");
       return;
     }
-    if (!IS_MAINTAINER) {
+    if (!isSponsor) {
       alert("Only maintainers can rate contributors.");
       return;
     }
@@ -142,7 +134,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
   };
 
   const renderActionButton = () => {
-    if (bounty.status === "IN_PROGRESS" && IS_MAINTAINER && !completed) {
+    if (bounty.status === "IN_PROGRESS" && isSponsor && !completed) {
       return (
         <Button
           onClick={handleMarkCompleted}
@@ -205,7 +197,7 @@ export function BountySidebar({ bounty }: BountySidebarProps) {
       {lastRating && reputationGain && (
         <div className="p-4 mb-4 rounded bg-green-900/60 text-green-200 border border-green-700">
           <div className="mb-1">
-            {IS_MAINTAINER
+            {isSponsor
               ? "You rated the contributor:"
               : "Contributor was rated:"}{" "}
             <b>{lastRating} / 5</b> stars


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>Closes #274.</p>
<p>Replaces the <code>NEXT_PUBLIC_MOCK_MAINTAINER</code> environment flag with the real
<code>useUserRole()</code> hook introduced in PR #254. The old constant was a dev shim
that bypassed session-based role checks entirely — the <code>console.warn</code> block in
the file itself flagged it as something that must never reach production. This
PR removes it and wires the sidebar to the actual authenticated session role.</p>
<hr>
<h2>Changes</h2>
<h3><code>components/bounty/bounty-sidebar.tsx</code></h3>
<p><strong>Removed:</strong></p>
<ul>
<li><code>const IS_MAINTAINER = process.env.NEXT_PUBLIC_MOCK_MAINTAINER === "true";</code>
(line 32)</li>
<li>The <code>console.warn</code> guard block (lines 34–41) that acknowledged the shim was
unsafe for production</li>
</ul>
<p><strong>Added:</strong></p>
<ul>
<li><code>import { useUserRole } from "@/hooks/use-user-role";</code></li>
<li><code>const role = useUserRole();</code> — reads the role from the live session via
<code>authClient.useSession()</code></li>
<li><code>const isSponsor = role === "sponsor";</code> — replaces every <code>IS_MAINTAINER</code>
reference throughout the component</li>
</ul>
<p><strong>No other files changed.</strong> No new env vars introduced.</p>
<hr>
<h2>Acceptance criteria</h2>
<ul>
<li>[x] No reference to <code>NEXT_PUBLIC_MOCK_MAINTAINER</code> remains in
<code>bounty-sidebar.tsx</code></li>
<li>[x] Maintainer-only UI (Mark as Completed, rate contributor) is visible to
users with the <code>sponsor</code> role and hidden for <code>contributor</code> users</li>
<li>[x] No new env vars required</li>
<li>[x] <code>console.warn</code> block removed</li>
</ul>
<hr>
<h2>How to test</h2>

Scenario | Expected result
-- | --
Signed in as a sponsor and bounty is IN_PROGRESS | "Mark as Completed" button is shown
Signed in as a contributor and bounty is IN_PROGRESS | "Mark as Completed" button is hidden; claim/status button shown instead
Not signed in (role === undefined) | Maintainer actions are hidden
Sponsor clicks "Mark as Completed" | Rating modal opens after simulated API call
Contributor triggers handleMarkCompleted directly (e.g. via devtools) | Alert: "Only maintainers can mark as completed."
Rating block shown after rating | Text reads "You rated the contributor:" for sponsors, "Contributor was rated:" for others


<hr>
<h2>Diff at a glance</h2>
<pre><code class="language-diff">-import { useClaimBounty } from "@/hooks/use-bounty-mutations";
+import { useClaimBounty } from "@/hooks/use-bounty-mutations";
+import { useUserRole } from "@/hooks/use-user-role";

-  // Mock maintainer check for now - in real app this comes from auth context
-  const IS_MAINTAINER = process.env.NEXT_PUBLIC_MOCK_MAINTAINER === "true";
-
-  if (
-    typeof window !== "undefined" &amp;&amp;
-    process.env.NEXT_PUBLIC_MOCK_MAINTAINER === "true"
-  ) {
-    console.warn(
-      "DEV: Mock maintainer enabled in components/bounty/bounty-sidebar.tsx — do NOT enable in production",
-    );
-  }
+  const role = useUserRole();
+  const isSponsor = role === "sponsor";

-  if (!IS_MAINTAINER) {          // handleMarkCompleted
+  if (!isSponsor) {

-  if (!IS_MAINTAINER) {          // handleSubmitRating
+  if (!isSponsor) {

-  if (bounty.status === "IN_PROGRESS" &amp;&amp; IS_MAINTAINER &amp;&amp; !completed) {
+  if (bounty.status === "IN_PROGRESS" &amp;&amp; isSponsor &amp;&amp; !completed) {

-  {IS_MAINTAINER
+  {isSponsor
</code></pre></body></html><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sponsor-only actions now use the signed-in user’s role for access control, improving consistency for marking bounties completed and submitting ratings.
  * The “Mark as Completed” action is shown only for eligible sponsors and only during the correct in-progress bounty state.
  * After submitting a rating, the success/reputation confirmation messaging now reflects the user’s role more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->