### PR TITLE
fix: remove leftover console.log in useSendMessage

### DIFF
--- a/hooks/use-bounty-application.ts
+++ b/hooks/use-bounty-application.ts
@@ -702,9 +702,6 @@ export function useSendMessage(bountyId: string) {
         timestamp: new Date().toISOString(),
       });
 
-      console.log(
-        `[useSendMessage] Recorded message for bountyId ${bountyId}: contributorId=${contributorId}, message="${message}"`,
-      );
       return { contributorId, message };
     },
   });


### PR DESCRIPTION
## Summary

Removes debug logging that leaks user message content into the browser console in production.

## Changes

- Delete `console.log` block at lines 705-707 in `hooks/use-bounty-application.ts`
- The mutation still resolves with `{ contributorId, message }` as before

## Why

The `console.log` was a dev-time tracer that was never removed. It fires on every single message recorded, leaking user message content into the browser console in production and adding noise during local dev.

Closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contributor messages are now stored with a timestamp when submitted.
  * Removed an unnecessary console message during message handling for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->