### PR TITLE
fix: wire up RaiseDisputeDialog in mobile CTA

### DIFF
--- a/components/bounty-detail/bounty-detail-mobile-cta.tsx
+++ b/components/bounty-detail/bounty-detail-mobile-cta.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { XCircle, Loader2, Users, Gavel } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -22,6 +23,7 @@ import {
   ApplicationDialog,
 } from "@/components/bounty/application-dialog";
 import { useBountyCTAState } from "./use-bounty-cta-state";
+import { RaiseDisputeDialog } from "./raise-dispute-dialog";
 
 type SidebarBounty = BountyFieldsFragment & Partial<Bounty>;
 
@@ -31,6 +33,8 @@ interface MobileCTAProps {
 }
 
 export function MobileCTA({ bounty, onCancelled }: MobileCTAProps) {
+  const [disputeDialogOpen, setDisputeDialogOpen] = useState(false);
+
   const {
     walletAddress,
     hasJoined,
@@ -179,17 +183,24 @@ export function MobileCTA({ bounty, onCancelled }: MobileCTAProps) {
         </div>
       )}
 
-      {/* Mobile Raise Dispute — coming soon */}
+      {/* Mobile Raise Dispute */}
       {canRaiseDispute && (
         <Button
           variant="ghost"
-          className="w-full mt-2 text-gray-400 text-xs h-8"
-          disabled
+          className="w-full mt-2 text-gray-400 hover:text-red-400 hover:bg-red-500/5 transition-all text-xs h-8"
+          onClick={() => setDisputeDialogOpen(true)}
         >
           <Gavel className="size-3 mr-2" />
-          Raise a Dispute (Coming Soon)
+          Raise a Dispute
         </Button>
       )}
+
+      {/* Mobile Raise Dispute Dialog */}
+      <RaiseDisputeDialog
+        open={disputeDialogOpen}
+        onOpenChange={setDisputeDialogOpen}
+        bountyId={bounty.id}
+      />
 
       {/* Mobile Cancel Dialog */}
       <AlertDialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>


### PR DESCRIPTION
## Summary

Brings the mobile Raise Dispute button to parity with the desktop sidebar by wiring up the existing `RaiseDisputeDialog` component.

## Changes

- Import `RaiseDisputeDialog` component
- Add `useState` for `disputeDialogOpen`
- Replace disabled "Coming Soon" button with enabled button that opens the dialog
- Render `RaiseDisputeDialog` with proper props

## Why

The mobile Raise Dispute button was a permanently disabled "Coming Soon" stub, but the flow already shipped in PRs #256 and #268. The desktop sidebar wires all of this up correctly. Mobile users currently have no way to raise a dispute because of the stale stub.

Closes #293