### PR TITLE
refactor: split bounty CTA branch logic into per-bounty-type components

### DIFF
--- a/components/bounty-detail/bounty-detail-sidebar-cta.tsx
+++ b/components/bounty-detail/bounty-detail-sidebar-cta.tsx
@@ -5,11 +5,9 @@ import {
   Github,
   Copy,
   Check,
-  AlertCircle,
   XCircle,
   Loader2,
   Users,
-  Clock,
   Gavel,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -28,16 +26,45 @@ import {
 
 import { BountyFieldsFragment } from "@/lib/graphql/generated";
 import { StatusBadge, TypeBadge } from "./bounty-badges";
-import { FcfsClaimButton } from "@/components/bounty/fcfs-claim-button";
 import { CompetitionSubmission } from "@/components/bounty/competition-submission";
 import { CompetitionStatus } from "@/components/bounty/competition-status";
 import type { CancellationRecord } from "@/types/escrow";
 import type { Bounty } from "@/types/bounty";
-import { ApplicationDialog } from "@/components/bounty/application-dialog";
 import { useBountyCTAState } from "./use-bounty-cta-state";
 import { RaiseDisputeDialog } from "./raise-dispute-dialog";
 
+import { FcfsCta } from "./cta/fcfs-cta";
+import { CompetitionCta } from "./cta/competition-cta";
+import { MultiWinnerCta } from "./cta/multi-winner-cta";
+import { MilestoneBasedCta } from "./cta/milestone-based-cta";
+import { DefaultCta } from "./cta/default-cta";
+
 type SidebarBounty = BountyFieldsFragment & Partial<Bounty>;
+
+interface BountyCtaProps {
+  bounty: SidebarBounty;
+  state: ReturnType<typeof useBountyCTAState>;
+}
+
+function BountyCta({ bounty, state }: BountyCtaProps) {
+  if (state.isFcfs) {
+    return <FcfsCta bounty={bounty} state={state} />;
+  }
+  if (state.isCompetition) {
+    return <CompetitionCta bounty={bounty} state={state} />;
+  }
+  if (
+    bounty.type === "MULTI_WINNER_MILESTONE" &&
+    state.canAct &&
+    !state.isCreator
+  ) {
+    return <MultiWinnerCta bounty={bounty} state={state} />;
+  }
+  if (bounty.type === "MILESTONE_BASED" && state.canAct && !state.isCreator) {
+    return <MilestoneBasedCta bounty={bounty} state={state} />;
+  }
+  return <DefaultCta bounty={bounty} state={state} />;
+}
 
 interface SidebarCTAProps {
   bounty: SidebarBounty;
@@ -47,13 +74,9 @@ interface SidebarCTAProps {
 export function SidebarCTA({ bounty, onCancelled }: SidebarCTAProps) {
   const [disputeDialogOpen, setDisputeDialogOpen] = useState(false);
 
+  const state = useBountyCTAState({ bounty, onCancelled });
   const {
-    walletAddress,
     hasJoined,
-    isPastDeadline,
-    joinMutation,
-    handleJoin,
-    handleApply,
     copied,
     handleCopy,
     cancelDialogOpen,
@@ -62,8 +85,6 @@ export function SidebarCTA({ bounty, onCancelled }: SidebarCTAProps) {
     setCancelReason,
     isCancelling,
     handleCancel,
-    canAct,
-    isFcfs,
     isCompetition,
     canRaiseDispute,
     canCancel,
@@ -72,14 +93,7 @@ export function SidebarCTA({ bounty, onCancelled }: SidebarCTAProps) {
     deadline,
     isFinalized,
     submissionCount,
-    ctaLabel,
-    isCreator,
-    applyForSlotMutation,
-    handleApplyForSlot,
-    isSlotsFull,
-    isAlreadyJoined,
-    applyForSlotButtonLabel,
-  } = useBountyCTAState({ bounty, onCancelled });
+  } = state;
 
   return (
     <div className="space-y-4">
@@ -149,102 +163,7 @@ export function SidebarCTA({ bounty, onCancelled }: SidebarCTAProps) {
         {isCompetition && <Separator className="bg-gray-800/60" />}
 
         {/* CTA */}
-        {isFcfs ? (
-          <FcfsClaimButton bounty={bounty} />
-        ) : isCompetition ? (
-          hasJoined ? (
-            <Button
-              className="w-full h-11 font-bold tracking-wide"
-              disabled
-              size="lg"
-            >
-              Joined ✓
-            </Button>
-          ) : (
-            <Button
-              data-testid="apply-to-bounty-btn"
-              className="w-full h-11 font-bold tracking-wide"
-              disabled={
-                !canAct ||
-                isPastDeadline ||
-                joinMutation.isPending ||
-                !walletAddress
-              }
-              size="lg"
-              onClick={() => void handleJoin()}
-            >
-              {joinMutation.isPending ? (
-                <Loader2 className="mr-2 size-4 animate-spin" />
-              ) : (
-                <Users className="mr-2 size-4" />
-              )}
-              {canAct && !isPastDeadline ? "Join Competition" : ctaLabel()}
-            </Button>
-          )
-        ) : bounty.type === "MULTI_WINNER_MILESTONE" && canAct && !isCreator ? (
-          <Button
-            className="w-full h-11 font-bold tracking-wide"
-            disabled={
-              isSlotsFull ||
-              isAlreadyJoined ||
-              !walletAddress ||
-              applyForSlotMutation.isPending
-            }
-            size="lg"
-            onClick={() => void handleApplyForSlot()}
-          >
-            {applyForSlotMutation.isPending ? (
-              <Loader2 className="mr-2 size-4 animate-spin" />
-            ) : (
-              <Users className="mr-2 size-4" />
-            )}
-            {applyForSlotButtonLabel}
-          </Button>
-        ) : bounty.type === "MILESTONE_BASED" && canAct && !isCreator ? (
-          <ApplicationDialog
-            bountyTitle={bounty.title}
-            onApply={handleApply}
-            trigger={
-              <Button
-                className="w-full h-11 font-bold tracking-wide"
-                size="lg"
-                disabled={!walletAddress}
-              >
-                Apply for Bounty
-              </Button>
-            }
-          />
-        ) : (
-          <Button
-            className="w-full h-11 font-bold tracking-wide"
-            disabled={!canAct}
-            size="lg"
-            onClick={() =>
-              canAct &&
-              window.open(
-                bounty.githubIssueUrl,
-                "_blank",
-                "noopener,noreferrer",
-              )
-            }
-          >
-            {ctaLabel()}
-          </Button>
-        )}
-
-        {/* Helper text when locked out */}
-        {isCompetition && !hasJoined && isPastDeadline && (
-          <p className="flex items-center gap-1.5 text-xs text-gray-500 justify-center text-center">
-            <Clock className="size-3 shrink-0" />
-            Submission deadline has passed.
-          </p>
-        )}
-        {!canAct && !isCompetition && (
-          <p className="flex items-center gap-1.5 text-xs text-gray-500 justify-center text-center">
-            <AlertCircle className="size-3 shrink-0" />
-            This bounty is no longer accepting new submissions.
-          </p>
-        )}
+        <BountyCta bounty={bounty} state={state} />
 
         {/* Raise Dispute */}
         {canRaiseDispute && (

--- a/components/bounty-detail/cta/competition-cta.tsx
+++ b/components/bounty-detail/cta/competition-cta.tsx
@@ -1,0 +1,74 @@
+import { Users, Loader2, Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { BountyFieldsFragment } from "@/lib/graphql/generated";
+import type { Bounty } from "@/types/bounty";
+import type { useBountyCTAState } from "../use-bounty-cta-state";
+
+type SidebarBounty = BountyFieldsFragment & Partial<Bounty>;
+
+interface CompetitionCtaProps {
+  bounty: SidebarBounty;
+  state: Pick<
+    ReturnType<typeof useBountyCTAState>,
+    | "hasJoined"
+    | "canAct"
+    | "isPastDeadline"
+    | "joinMutation"
+    | "walletAddress"
+    | "handleJoin"
+    | "ctaLabel"
+  >;
+}
+
+export function CompetitionCta({ state }: CompetitionCtaProps) {
+  const {
+    hasJoined,
+    canAct,
+    isPastDeadline,
+    joinMutation,
+    walletAddress,
+    handleJoin,
+    ctaLabel,
+  } = state;
+
+  return (
+    <>
+      {hasJoined ? (
+        <Button
+          className="w-full h-11 font-bold tracking-wide"
+          disabled
+          size="lg"
+        >
+          Joined ✓
+        </Button>
+      ) : (
+        <Button
+          data-testid="apply-to-bounty-btn"
+          className="w-full h-11 font-bold tracking-wide"
+          disabled={
+            !canAct ||
+            isPastDeadline ||
+            joinMutation.isPending ||
+            !walletAddress
+          }
+          size="lg"
+          onClick={() => void handleJoin()}
+        >
+          {joinMutation.isPending ? (
+            <Loader2 className="mr-2 size-4 animate-spin" />
+          ) : (
+            <Users className="mr-2 size-4" />
+          )}
+          {canAct && !isPastDeadline ? "Join Competition" : ctaLabel()}
+        </Button>
+      )}
+
+      {!hasJoined && isPastDeadline && (
+        <p className="flex items-center gap-1.5 text-xs text-gray-500 justify-center text-center">
+          <Clock className="size-3 shrink-0" />
+          Submission deadline has passed.
+        </p>
+      )}
+    </>
+  );
+}

--- a/components/bounty-detail/cta/default-cta.tsx
+++ b/components/bounty-detail/cta/default-cta.tsx
@@ -1,0 +1,39 @@
+import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { BountyFieldsFragment } from "@/lib/graphql/generated";
+import type { Bounty } from "@/types/bounty";
+import type { useBountyCTAState } from "../use-bounty-cta-state";
+
+type SidebarBounty = BountyFieldsFragment & Partial<Bounty>;
+
+interface DefaultCtaProps {
+  bounty: SidebarBounty;
+  state: Pick<ReturnType<typeof useBountyCTAState>, "canAct" | "ctaLabel">;
+}
+
+export function DefaultCta({ bounty, state }: DefaultCtaProps) {
+  const { canAct, ctaLabel } = state;
+
+  return (
+    <>
+      <Button
+        className="w-full h-11 font-bold tracking-wide"
+        disabled={!canAct}
+        size="lg"
+        onClick={() =>
+          canAct &&
+          window.open(bounty.githubIssueUrl, "_blank", "noopener,noreferrer")
+        }
+      >
+        {ctaLabel()}
+      </Button>
+
+      {!canAct && (
+        <p className="flex items-center gap-1.5 text-xs text-gray-500 justify-center text-center">
+          <AlertCircle className="size-3 shrink-0" />
+          This bounty is no longer accepting new submissions.
+        </p>
+      )}
+    </>
+  );
+}

--- a/components/bounty-detail/cta/fcfs-cta.tsx
+++ b/components/bounty-detail/cta/fcfs-cta.tsx
@@ -1,0 +1,28 @@
+import { FcfsClaimButton } from "@/components/bounty/fcfs-claim-button";
+import { AlertCircle } from "lucide-react";
+import type { BountyFieldsFragment } from "@/lib/graphql/generated";
+import type { Bounty } from "@/types/bounty";
+import type { useBountyCTAState } from "../use-bounty-cta-state";
+
+type SidebarBounty = BountyFieldsFragment & Partial<Bounty>;
+
+interface FcfsCtaProps {
+  bounty: SidebarBounty;
+  state: Pick<ReturnType<typeof useBountyCTAState>, "canAct">;
+}
+
+export function FcfsCta({ bounty, state }: FcfsCtaProps) {
+  const { canAct } = state;
+
+  return (
+    <>
+      <FcfsClaimButton bounty={bounty} />
+      {!canAct && (
+        <p className="flex items-center gap-1.5 text-xs text-gray-500 justify-center text-center">
+          <AlertCircle className="size-3 shrink-0" />
+          This bounty is no longer accepting new submissions.
+        </p>
+      )}
+    </>
+  );
+}

--- a/components/bounty-detail/cta/milestone-based-cta.tsx
+++ b/components/bounty-detail/cta/milestone-based-cta.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/ui/button";
+import { ApplicationDialog } from "@/components/bounty/application-dialog";
+import type { BountyFieldsFragment } from "@/lib/graphql/generated";
+import type { Bounty } from "@/types/bounty";
+import type { useBountyCTAState } from "../use-bounty-cta-state";
+
+type SidebarBounty = BountyFieldsFragment & Partial<Bounty>;
+
+interface MilestoneBasedCtaProps {
+  bounty: SidebarBounty;
+  state: Pick<
+    ReturnType<typeof useBountyCTAState>,
+    "walletAddress" | "handleApply"
+  >;
+}
+
+export function MilestoneBasedCta({ bounty, state }: MilestoneBasedCtaProps) {
+  const { walletAddress, handleApply } = state;
+
+  return (
+    <ApplicationDialog
+      bountyTitle={bounty.title}
+      onApply={handleApply}
+      trigger={
+        <Button
+          className="w-full h-11 font-bold tracking-wide"
+          size="lg"
+          disabled={!walletAddress}
+        >
+          Apply for Bounty
+        </Button>
+      }
+    />
+  );
+}

--- a/components/bounty-detail/cta/multi-winner-cta.tsx
+++ b/components/bounty-detail/cta/multi-winner-cta.tsx
@@ -1,0 +1,52 @@
+import { Users, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { BountyFieldsFragment } from "@/lib/graphql/generated";
+import type { Bounty } from "@/types/bounty";
+import type { useBountyCTAState } from "../use-bounty-cta-state";
+
+type SidebarBounty = BountyFieldsFragment & Partial<Bounty>;
+
+interface MultiWinnerCtaProps {
+  bounty: SidebarBounty;
+  state: Pick<
+    ReturnType<typeof useBountyCTAState>,
+    | "isSlotsFull"
+    | "isAlreadyJoined"
+    | "walletAddress"
+    | "applyForSlotMutation"
+    | "handleApplyForSlot"
+    | "applyForSlotButtonLabel"
+  >;
+}
+
+export function MultiWinnerCta({ state }: MultiWinnerCtaProps) {
+  const {
+    isSlotsFull,
+    isAlreadyJoined,
+    walletAddress,
+    applyForSlotMutation,
+    handleApplyForSlot,
+    applyForSlotButtonLabel,
+  } = state;
+
+  return (
+    <Button
+      className="w-full h-11 font-bold tracking-wide"
+      disabled={
+        isSlotsFull ||
+        isAlreadyJoined ||
+        !walletAddress ||
+        applyForSlotMutation.isPending
+      }
+      size="lg"
+      onClick={() => void handleApplyForSlot()}
+    >
+      {applyForSlotMutation.isPending ? (
+        <Loader2 className="mr-2 size-4 animate-spin" />
+      ) : (
+        <Users className="mr-2 size-4" />
+      )}
+      {applyForSlotButtonLabel}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Description
Resolves #297.

This PR refactors the call-to-action (CTA) rendering logic inside `components/bounty-detail/bounty-detail-sidebar-cta.tsx`. The previously giant cascading conditional ternary that selected the appropriate CTA button based on the bounty type has been split into dedicated, modular sub-components.

## Changes Made
Created a new directory `components/bounty-detail/cta/` and extracted the branch rendering logic into five separate components:
1. **`fcfs-cta.tsx`**: Wraps the `FcfsClaimButton` and handles showing the fallback alert text if the FCFS bounty is no longer active (`!canAct`).
2. **`competition-cta.tsx`**: Renders competition CTA buttons (e.g. "Joined ✓" state, "Join Competition" with load spinners and deadlines), and the past-deadline lockout warning.
3. **`multi-winner-cta.tsx`**: Renders the apply-for-slot button for multi-winner milestone bounties, with slot fullness and already-joined validations.
4. **`milestone-based-cta.tsx`**: Wraps the `<ApplicationDialog>` trigger and button component for milestone-based bounties.
5. **`default-cta.tsx`**: Renders the fallback "View on GitHub" link or the closed-bounty message for when no other actions are applicable.

### Main Component Simplified
- **`bounty-detail-sidebar-cta.tsx`**: Replaced the 100+ line cascading ternary block with a single `<BountyCta bounty={bounty} state={state} />` dispatch component.
- Reduced unused variables and cleaned up unused imports (`AlertCircle`, `Clock`, `ApplicationDialog`, `FcfsClaimButton`).
- Hoisted state from the parent `SidebarCTA` component and passed the required state properties down to the sub-components using strong TypeScript typing.

## Verification
- **TypeScript**: `pnpm tsc --noEmit` compiled successfully with 0 errors.
- **ESLint**: `pnpm lint` and `eslint` checked and verified with 0 errors/warnings.
- **Unit Tests**: Full unit test suite (`16 passed, 16 total` / `94 tests passed`) successfully ran and passed:
  ```bash
  PASS hooks/__tests__/use-cancel-bounty.test.ts
  PASS hooks/__tests__/use-bounty-subscription.test.ts
  PASS hooks/__tests__/use-bounty-filters.test.ts
  ...
  Test Suites: 16 passed, 16 total
  Tests:       94 passed, 94 total


closes #297 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bounty detail sidebar actions with clearer, flow-specific call-to-actions for competition, FCFS, multi-winner, milestone-based, and default bounty types.
  * Added clearer status states for joining, applying, and locked submissions, including disabled actions when a bounty is no longer accepting entries.
  * Added deadline and availability messaging to help users understand why an action may be unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->