### PR TITLE
feat: use badge pill for hero eyebrow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,9 +11,11 @@ export default function Home() {
 
       <HeroBackground fieldHeight={640} fadeBottom>
         <Section className='py-24 text-center lg:py-32'>
-          <span className='text-caption-sm text-primary-500 uppercase'>
-            Boundless Builders
-          </span>
+          <div className='inline-flex items-center rounded-full border border-white/10 bg-white/5 p-1 text-body-xs text-white/70'>
+            <span className='rounded-full bg-white/10 px-3 py-1 font-medium text-white'>
+              Boundless Builders
+            </span>
+          </div>
           <h1 className='mt-6 text-display-sm text-foreground lg:text-display-lg'>
             Discover the builders shipping on{' '}
             <span className='text-primary-500'>Stellar</span>


### PR DESCRIPTION
## Use the badge pill for the hero eyebrow

Replaces the plain uppercase caption above the hero heading with the marketing
badge pill, matching the pattern used on the boundless-platform landing hero.

### Before

```tsx
<span className='text-caption-sm text-primary-500 uppercase'>
  Boundless Builders
</span>
```

### After

```tsx
<div className='inline-flex items-center rounded-full border border-white/10 bg-white/5 p-1 text-body-xs text-white/70'>
  <span className='rounded-full bg-white/10 px-3 py-1 font-medium text-white'>
    Boundless Builders
  </span>
</div>
```

### Notes

- The badge keeps the bordered translucent outer pill wrapping a raised inner
  pill, exactly as used on the main platform.
- No `Learn More` link or arrow, so the badge reads as a label rather than a call
  to action. The `gap-1` was dropped since it only existed to space the pill from
  that link.

### Checks

- [x] `npm run lint` passes
- [x] `npm run build` passes (also type-checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Boundless Builders” hero callout with a pill-shaped design, including refined typography, borders, and background styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->