### PR TITLE
docs: align ENDPOINTS.md with implemented backend public reads

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -5,197 +5,145 @@ created and managed in the main Boundless app. Every read comes from the shared
 `boundless-nestjs` backend, so this app and boundless-platform stay consistent
 (a project or user followed in the platform is read here from the same data).
 
-This document maps each screen to the endpoints it needs, marking what already
-exists versus what has to be built or opened up.
+The public read API was implemented by the backend team. This document mirrors
+`boundless-nestjs/docs/builders-public-reads.md` and maps each endpoint to the
+screen that uses it. If the two ever drift, the backend doc is the source of
+truth.
 
-## Rules
+## Rules and conventions
 
 - This app calls **`GET` endpoints only**. All writes (follow, create, edit,
   upload) stay in boundless-platform.
 - Follows and profiles are stored once and shared. We reuse the same reads, we
   do not duplicate the data model.
-- Paths below are backend routes. The frontend reaches them through the `/api`
-  proxy, so `GET /projects` is `GET /api/projects` from the client.
+- **Prefix:** every path is served under the global `/api` prefix. `GET /projects`
+  is `GET /api/projects`. Base URL comes from `NEXT_PUBLIC_API_URL`
+  (staging: `https://stage-api.boundlessfi.xyz`).
+- **Auth:** the backend runs a global session guard. These routes opt out with
+  `@AllowAnonymous()`, so they are public. Personalize-if-present routes use
+  `@OptionalAuth()`.
+- **No PII:** public reads never return `email` or other sensitive account
+  fields. Identity and user-authored public profile fields only.
+- **Pagination:** list responses return
+  `{ data, pagination: { page, limit, total, totalPages, hasNext, hasPrev } }`.
 
-## Legend
+## Status legend
 
-- **Exists (public)**: already `@AllowAnonymous` / `@Public`. Reuse as-is.
-- **Exists (auth-gated)**: the endpoint exists but is behind `AuthGuard`. Needs a
-  public or optional-auth variant for this app.
-- **Needed**: no endpoint yet. Must be added in `boundless-nestjs`.
+- **Public**: implemented and public. Use directly.
+- **Private-aware**: public, but returns `404` when the target profile is
+  private.
 
 ---
 
 ## `/` — Home / Landing
 
-### Existing (reuse)
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /leaderboard` | Top builders row (`limit`, `page`, `timeframe`, `tier`) | Public |
+| `GET /projects/featured` | Featured projects row | Public |
+| `GET /discover/landing` | Ecosystem feed / counts | Public |
+| `GET /discover/recent-winners` | Recent winners highlight | Public |
+| `GET /users/directory?limit=N` | Fallback source for a builders strip | Public |
 
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /projects/featured` | Featured projects |
-| `GET /discover/landing` | Ecosystem stats and counts |
-| `GET /discover/recent-winners` | Highlights |
-
-### Needed
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /users?featured=true` | Featured builders strip (depends on the new public builders list) |
+> There is no "featured builders" flag. The landing "top builders" row uses
+> `GET /leaderboard`. A stats strip can derive counts from the `pagination.total`
+> of `GET /users/directory`, `GET /projects`, and `GET /organizations`.
 
 ---
 
 ## `/builders` — Builders Directory
 
-### Existing (reuse)
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /users/directory` | Public builders directory. Filters: `country`, `skills` (repeatable/CSV), `status`, `search`, `sort` (`name_asc\|name_desc\|newest\|oldest`), `page`, `limit`. Public profiles only. | Public |
+| `GET /users/filters` | Facets: `skills[]`, `countries[]` (with counts), `statuses[]` | Public |
 
-None. The only user list today, `GET /users`, is Admin-only.
-
-### Needed
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /users` | Public, paginated, filterable builders list (`?country=&skills=&status=&sort=name_asc&page=`) |
-| `GET /users/filters` | Filter option lists (skills, countries, statuses) |
+> The directory is `GET /users/directory`, **not** `GET /users`. `GET /users` is
+> Admin-only and is not used by this app.
 
 ---
 
 ## `/builders/[username]` — Builder Profile
 
-### Existing (reuse)
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /users/:username` | Profile header (bio, role, location, follow status) |
-| `GET /users/:username/followers` | Followers list |
-| `GET /users/:username/following` | Following list |
-| `GET /projects?builder=:username` | Their projects (confirm the filter param) |
-
-### Needed
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /users/:username/stats` | Public stats (projects, contributions, earnings). The current `GET /users/profile/stats` is auth-only for the own profile. |
-| `GET /users/:username/activity` | Public activity feed by username. The current `GET /users/profile/activity/public` is not username-scoped. |
-| `GET /users/:username/organizations` | Teams this builder belongs to |
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /users/:username` | Public profile. Embeds orgs, projects, stats, followStats. | Public |
+| `GET /users/:username/stats` | Public profile stats + follow counts | Private-aware |
+| `GET /users/:username/activity` | Contribution timeline (`limit`, `offset`) | Private-aware |
+| `GET /users/:username/organizations` | Teams the builder belongs to, with role | Private-aware |
+| `GET /users/:username/followers` · `/following` | Follower / following lists | Public |
+| `GET /projects?creatorId=:userId` | The builder's projects | Public |
 
 ---
 
 ## `/projects` — Projects / Products Directory
 
-### Existing (reuse)
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /projects` | Project cards, paginated with filters |
-| `GET /projects/search` | Search |
-
-### Needed
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /projects/filters` | Filter facets (category, stage, network, sector) |
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /projects` | Directory. Filters: `creatorId`, `organizationId`, `tags` (repeatable/CSV), `category`, `publicStatus`, `originType`, `featured`, `search`. Never returns `IDEA` drafts. | Public |
+| `GET /projects/search` | Search public projects | Public |
+| `GET /projects/filters` | Facets: `categories[]` + `tags[]` (with counts), `publicStatuses[]`, `originTypes[]` | Public |
 
 ---
 
 ## `/projects/[slug]` — Project Detail
 
-### Existing (reuse)
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /projects/:slug` | Project header and body |
-| `GET /bounties?projectId=` | Related bounties |
-| `GET /grants?projectId=` | Related grants |
-
-### Needed
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /projects/:slug/members` | Team and contributors |
-| `GET /follows/entity/project/:id/followers` | Followers. Exists but auth-gated; needs a public variant. |
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /projects/:slug` | Project header and body (PII-scrubbed) | Public |
+| `GET /projects/:slug/members` | Contributor roster (from `ProjectMember`). Creator always included as `owner`. Drafts 404. | Public |
+| `GET /follows/entity/project/:id/followers` | Project follower list. The generic `entity/:entityType/:entityId/followers` route stays authenticated. | Public |
+| `GET /bounties?projectId=` · `GET /grants?projectId=` | Related opportunities | Public |
 
 ---
 
 ## `/teams` — Teams / Organizations Directory
 
-### Existing (reuse)
-
-None public. The list and search are auth-gated today.
-
-### Needed
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /organizations` | Public variant of the list (currently behind `AuthGuard`) |
-| `GET /organizations/search` | Public variant of search (currently behind `AuthGuard`) |
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /organizations` | Public directory. `search`, `sortBy` (`createdAt\|name`), `sortOrder`, `page`, `limit`. Counts only, no member PII. | Public |
+| `GET /organizations/search` | Search organizations | Public |
 
 ---
 
 ## `/teams/[slug]` — Team Detail
 
-### Existing (reuse)
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /organizations/profile/:idOrSlug` | Team profile |
-| `GET /organizations/profile/:idOrSlug/funded` | Funded and supported projects |
-
-### Needed
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /organizations/:id/members` | Members. Exists but auth-gated; needs a public variant. |
-| `GET /organizations/:id/stats` | Stats. Exists but auth-gated; needs a public variant. |
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /organizations/profile/:idOrSlug` | Team profile | Public |
+| `GET /organizations/profile/:idOrSlug/funded` | Funded / supported projects | Public |
+| `GET /organizations/:id/members` | Public roster (identity fields only, capped, with `total`) | Public |
+| `GET /organizations/:id/stats` | Projects / hackathons / bounties / grants / participants / prize pool + followers | Public |
 
 ---
 
-## Cross-cutting (used on multiple screens)
+## Cross-cutting
 
-### Existing (reuse)
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /leaderboard` | Leaderboard widget |
-| `GET /follows/:entityType/:entityId/check` | "Am I following" state. Only if this app has logged-in sessions. Auth-gated by nature. |
+| Endpoint | Purpose | Status |
+| --- | --- | --- |
+| `GET /leaderboard` | Leaderboard widget | Public |
+| `GET /follows/:entityType/:entityId/check` | "Am I following" state (only if this app has logged-in sessions) | Auth |
 
 ### Not built here (boundary)
 
-| Endpoint | Note |
-| --- | --- |
-| `POST` / `DELETE /follows/:entityType/:entityId` | Follow and unfollow. Writes stay in boundless-platform. This app never calls it. |
+`POST` / `DELETE /follows/:entityType/:entityId` and every other write stay in
+boundless-platform. This app never calls them.
 
 ---
 
-## Summary
+## Backend schema notes
 
-### Reuse as-is (already public)
+From migration `20260725000000_builders_public_reads`:
 
-Projects (list, search, featured, detail), builder profile plus followers and
-following, team profile plus funded, discover, leaderboard.
+- `BuilderStatus` enum (`AVAILABLE`, `OPEN_TO_WORK`, `BUSY`, `UNAVAILABLE`) and
+  indexed `UserProfile.country` / `UserProfile.status` back the directory filters
+  and facets.
+- `ProjectMember` model (`projectId`, `userId`, `role`, `joinedAt`) is the
+  first-class replacement for the untyped `Project.teamMembers` JSON and backs
+  `GET /projects/:slug/members`.
 
-### Build 7 new public reads
-
-1. `GET /users` — public builders directory with filters
-2. `GET /users/filters` — builder filter facets
-3. `GET /users/:username/stats` — public builder stats
-4. `GET /users/:username/activity` — public builder activity
-5. `GET /users/:username/organizations` — a builder's teams
-6. `GET /projects/filters` — project filter facets
-7. `GET /projects/:slug/members` — project contributors
-
-### Open 4 existing endpoints to public
-
-1. `GET /organizations` — list
-2. `GET /organizations/search` — search
-3. `GET /organizations/:id/members` — members
-4. `GET /organizations/:id/stats` — stats
-
-Plus the entity-level project followers read
-`GET /follows/entity/project/:id/followers`.
-
-### Shared data
+## Shared data
 
 Follows and profiles are stored once and read by both apps. A user or project
 followed in boundless-platform is read here through the same endpoints. Nothing
-is duplicated. The only care point is that some of those reads are auth-gated
-today and need a public or optional-auth variant, not a new data model.
+is duplicated.


### PR DESCRIPTION
Updates `ENDPOINTS.md` to mirror `boundless-nestjs/docs/builders-public-reads.md` now that Collins implemented the public read API.

Key corrections:
- Builders directory is `GET /users/directory` (not `GET /users`, which is Admin-only).
- Marks as implemented: `/users/filters`, `/users/:username/stats|activity|organizations`, `/projects/filters`, `/projects/:slug/members`, public `/organizations` list/search/members/stats, and public project followers.
- Projects filter by `creatorId` (not `?builder=`).
- Adds conventions: `/api` prefix, `NEXT_PUBLIC_API_URL` base, pagination envelope, no PII.
- Adds backend schema notes (`BuilderStatus`, `ProjectMember`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the endpoint planning guide with a status-driven reference for read-only API usage.
  * Documented GET endpoints, filters, pagination, authentication behavior, and privacy handling for key screens.
  * Added a status legend distinguishing public endpoints from private-aware endpoints.
  * Clarified shared follow and profile data, including the separation between read and write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->