### PR TITLE
feat(cards): add BuilderCard component and skeleton

### DIFF
--- a/components/cards/builder-card-skeleton.tsx
+++ b/components/cards/builder-card-skeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+/** Loading placeholder that mirrors the BuilderCard layout. */
+export function BuilderCardSkeleton() {
+  return (
+    <div className='flex flex-col gap-5 rounded-2xl border border-border bg-ink p-4'>
+      <div className='flex items-center gap-3'>
+        <Skeleton className='size-10 rounded-full' />
+        <div className='flex flex-1 flex-col gap-1.5'>
+          <Skeleton className='h-4 w-32' />
+          <Skeleton className='h-3.5 w-20' />
+        </div>
+      </div>
+
+      <Skeleton className='h-4 w-48' />
+
+      <Skeleton className='h-4 w-28' />
+
+      <div className='flex flex-wrap gap-1.5'>
+        <Skeleton className='h-5 w-16 rounded-full' />
+        <Skeleton className='h-5 w-20 rounded-full' />
+        <Skeleton className='h-5 w-14 rounded-full' />
+      </div>
+
+      <span aria-hidden className='h-px w-full bg-border' />
+
+      <div className='flex items-center gap-4'>
+        <Skeleton className='h-4 w-24' />
+        <Skeleton className='h-4 w-20' />
+      </div>
+    </div>
+  );
+}

--- a/components/cards/builder-card.tsx
+++ b/components/cards/builder-card.tsx
@@ -1,0 +1,127 @@
+import { Folder, MapPin, type LucideIcon, Users } from 'lucide-react';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+import { Avatar } from '@/components/ui/avatar';
+import { deriveInitials } from '@/lib/initials';
+import { cn } from '@/lib/utils';
+
+import type { BuilderCardView } from './types';
+
+function Meta({
+  icon: Icon,
+  children,
+  className,
+}: {
+  icon: LucideIcon;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'flex items-center gap-1 text-xs font-medium text-muted-foreground',
+        className
+      )}
+    >
+      <Icon className='size-4 shrink-0' strokeWidth={1.75} aria-hidden />
+      <span className='truncate'>{children}</span>
+    </span>
+  );
+}
+
+/** A single builder card in the discovery grid or /builders directory. */
+export function BuilderCard({
+  builder,
+}: {
+  builder: BuilderCardView;
+}) {
+  const {
+    displayName,
+    username,
+    avatarSrc,
+    role,
+    location,
+    skills: rawSkills,
+    followers,
+    projects,
+    detailUrl,
+  } = builder;
+  const skills = rawSkills ?? [];
+
+  return (
+    <Link
+      href={detailUrl}
+      aria-label={displayName}
+      className='group block h-full min-w-0 rounded-2xl focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:outline-none'
+    >
+      <article className='flex h-full min-w-0 flex-col gap-5 rounded-2xl border border-border bg-ink p-4 transition-[transform,border-color] duration-200 group-hover:border-[#2a3a37] motion-reduce:transition-none'>
+        {/* Header: avatar + name + username */}
+        <div className='flex items-center gap-3'>
+          <Avatar
+            src={avatarSrc}
+            initials={deriveInitials(displayName)}
+            alt={displayName}
+            size='md'
+            className='shrink-0'
+          />
+          <div className='min-w-0 flex-1'>
+            <h3 className='truncate text-base font-semibold text-foreground'>
+              {displayName}
+            </h3>
+            <p className='truncate text-sm text-muted-foreground'>
+              @{username}
+            </p>
+          </div>
+        </div>
+
+        {/* Variable content: role, location, skills — stretches to keep cards equal-height */}
+        <div className='flex flex-1 flex-col gap-5'>
+          {/* Role / title */}
+          {role && (
+            <p className='text-body-sm text-muted-foreground'>{role}</p>
+          )}
+
+          {/* Location */}
+          {location && (
+            <Meta icon={MapPin} className='shrink-0'>
+              {location}
+            </Meta>
+          )}
+
+          {/* Skills */}
+          {skills.length > 0 && (
+            <div className='flex flex-wrap gap-1.5'>
+              {skills.map((skill) => (
+                <span
+                  key={skill}
+                  className='rounded-[12px] bg-[rgba(234,253,247,0.08)] px-2 py-0.5 text-xs font-medium text-primary-700'
+                >
+                  {skill}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <span aria-hidden className='h-px w-full bg-border' />
+
+        {/* Follower / project counts */}
+        <div className='flex items-center justify-between gap-4'>
+          {followers !== undefined && (
+            <Meta icon={Users} className='shrink-0'>
+              {followers.toLocaleString()}{' '}
+              {followers === 1 ? 'follower' : 'followers'}
+            </Meta>
+          )}
+          {projects !== undefined && (
+            <Meta icon={Folder} className='shrink-0'>
+              {projects.toLocaleString()}{' '}
+              {projects === 1 ? 'project' : 'projects'}
+            </Meta>
+          )}
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/components/cards/types.ts
+++ b/components/cards/types.ts
@@ -12,6 +12,28 @@ export type OpportunityCardStatus =
   | 'review'
   | 'completed';
 
+export interface BuilderCardView {
+  id: string;
+  /** The builder's display name (e.g. "Jane Doe"). */
+  displayName: string;
+  /** URL-safe username (e.g. "janedoe"). */
+  username: string;
+  /** Optional avatar image URL. */
+  avatarSrc?: string;
+  /** Professional role or title (e.g. "Full-stack developer"). */
+  role?: string;
+  /** Country or city label (e.g. "Nigeria"). */
+  location?: string;
+  /** Up to 3-4 skill labels. */
+  skills?: string[];
+  /** Follower count when available. */
+  followers?: number;
+  /** Project count when available. */
+  projects?: number;
+  /** Profile page path so cards can link out. */
+  detailUrl: string;
+}
+
 export interface OpportunityCardView {
   id: string;
   org: string;


### PR DESCRIPTION
## Summary
 
Adds a reusable `BuilderCard` presentational component for the landing page's "Top builders" row and the future `/builders` directory, along with its loading skeleton.
 
## Changes
 
- **`components/cards/types.ts`** — Added `BuilderCardView` interface (id, displayName, username, avatarSrc, role, location, skills, followers, projects, detailUrl).
- **`components/cards/builder-card.tsx`** — New presentational `BuilderCard` component that takes a `BuilderCardView` prop and renders avatar (with initials fallback), display name, `@username`, role, location, skill chips, and follower/project counts. Wraps the entire card in a `Link` to `/builders/[username]`. Mirrors `OpportunityCard` structure (Meta helper, `group`/`focus-visible` states, `bg-ink` surface, `border-border`, hover transitions, equal-height layout via `flex-1`).
- **`components/cards/builder-card-skeleton.tsx`** — New `BuilderCardSkeleton` that mirrors the card layout with `Skeleton` placeholders.
 
## Design system compliance
 
- Uses design tokens only (`bg-ink`, `border-border`, `text-foreground`,`text-muted-foreground`, `text-primary-700`, `rounded-2xl`, `text-body-sm`, etc.).
- Reuses `Avatar`, `deriveInitials`, `Skeleton`, and lucide-react icons.
- No raw hex values except `group-hover:border-[#2a3a37]` and `bg-[rgba(234,253,247,0.08)]` — matching the existing `OpportunityCard` pattern.
 
## Verification
 
- [x] `npm run lint` passes
- [x] `npm run build` passes (TypeScript + production build)
- [x] Visuals verified on `/test/builders` (test page removed before PR)
- [x] All three states tested: complete data, minimal data, skeleton loading
- [x] Equal card height verified in grid layout

## Screenshots
<img width="1319" height="834" alt="Screenshot 2026-07-25 at 23 49 34" src="https://github.com/user-attachments/assets/0fe9ba8c-1dba-4578-ad18-4ef69bc344e8" />


<img width="1320" height="835" alt="Screenshot 2026-07-25 at 23 49 22" src="https://github.com/user-attachments/assets/b4895fb2-92f7-46e6-94ff-101b7b26675d" />

Closes #319 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added builder profile cards displaying avatars, names, usernames, roles, locations, skills, follower counts, and project counts.
  - Added navigation from builder cards to detailed profile pages.
  - Added loading placeholders that match the builder card layout.
  - Added support for optional profile information and consistent card data formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->