### PR TITLE
chore: track .env.example with the staging API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+https://stage-api.boundlessfi.xyz/

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
 
 # vercel
 .vercel


### PR DESCRIPTION
Stop ignoring .env.example (switch the ignore rule from .env* to .env and .env.local) so contributors get a checked-in template, and add the staging boundless-nestjs base URL to it. The API-client setup issue (#318) formalizes this into a named NEXT_PUBLIC_API_URL var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the example environment configuration with the staging API address.
  * Refined environment-file ignore rules to distinguish local configuration files from other environment-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->