### PR TITLE
feat(landing): add top builders section

### DIFF
--- a/components/landing/to-builder-card.ts
+++ b/components/landing/to-builder-card.ts
@@ -1,0 +1,52 @@
+import type { BuilderCardView } from '@/components/cards/types';
+
+const MAX_SKILLS = 4;
+
+export interface LeaderboardStats {
+  totalCompleted: number;
+  totalWins: number;
+  totalEarnings: number;
+  earningsCurrency: string;
+  totalEarningsUsdc: number;
+  completionRate: number;
+  averageCompletionTime: number;
+  currentStreak: number;
+  longestStreak: number;
+}
+
+export interface LeaderboardContributor {
+  id: string;
+  userId: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  totalScore: number;
+  tier: string;
+  stats: LeaderboardStats;
+  topTags: string[];
+  lastActiveAt: string;
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  contributor: LeaderboardContributor;
+}
+
+export interface LeaderboardData {
+  entries: LeaderboardEntry[];
+  totalCount: number;
+  lastUpdatedAt: string;
+}
+
+export function toBuilderCard({
+  contributor,
+}: LeaderboardEntry): BuilderCardView {
+  return {
+    id: contributor.id,
+    displayName: contributor.displayName,
+    username: contributor.username,
+    avatarSrc: contributor.avatarUrl ?? undefined,
+    skills: contributor.topTags.slice(0, MAX_SKILLS),
+    detailUrl: `/builders/${contributor.username}`,
+  };
+}

--- a/components/landing/top-builders.tsx
+++ b/components/landing/top-builders.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
+
+import { BuilderCard } from '@/components/cards/builder-card';
+import { BuilderCardSkeleton } from '@/components/cards/builder-card-skeleton';
+import { ArrowRightIcon } from '@/components/icons';
+import { Section, SectionHeading } from '@/components/marketing/section';
+import { Button } from '@/components/ui/button';
+import { apiFetch } from '@/lib/api/client';
+
+import {
+  type LeaderboardData,
+  toBuilderCard,
+} from './to-builder-card';
+
+const TOP_BUILDERS_LIMIT = 8;
+
+function useTopBuilders() {
+  return useQuery({
+    queryKey: ['leaderboard', 'top-builders', TOP_BUILDERS_LIMIT],
+    queryFn: () =>
+      apiFetch<LeaderboardData>(
+        `/leaderboard?limit=${TOP_BUILDERS_LIMIT}`
+      ),
+  });
+}
+
+function TopBuildersSkeleton() {
+  return (
+    <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4'>
+      {Array.from({ length: TOP_BUILDERS_LIMIT }, (_, index) => (
+        <BuilderCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <p className='text-center text-body-sm text-muted-foreground'>
+      No builders to show yet.
+    </p>
+  );
+}
+
+export function TopBuilders() {
+  const { data, isError, isPending } = useTopBuilders();
+  const builders = data?.entries.map(toBuilderCard) ?? [];
+
+  return (
+    <Section innerClassName='flex flex-col gap-8'>
+      <SectionHeading
+        eyebrow='Leaderboard'
+        title='Top builders'
+        description='Meet the builders making an impact across the Boundless ecosystem.'
+      />
+
+      {isPending ? (
+        <TopBuildersSkeleton />
+      ) : isError ? (
+        <p className='text-center text-body-sm text-muted-foreground'>
+          Top builders could not be loaded right now.
+        </p>
+      ) : builders.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4'>
+          {builders.map((builder) => (
+            <BuilderCard key={builder.id} builder={builder} />
+          ))}
+        </div>
+      )}
+
+      <div className='flex justify-center'>
+        <Button
+          intent='secondary'
+          appearance='outline'
+          size='large'
+          asChild
+        >
+          <Link href='/builders'>
+            View all builders
+            <ArrowRightIcon aria-hidden />
+          </Link>
+        </Button>
+      </div>
+    </Section>
+  );
+}

--- a/components/landing/top-builders.tsx
+++ b/components/landing/top-builders.tsx
@@ -52,7 +52,6 @@ export function TopBuilders() {
   return (
     <Section innerClassName='flex flex-col gap-8'>
       <SectionHeading
-        eyebrow='Leaderboard'
         title='Top builders'
         description='Meet the builders making an impact across the Boundless ecosystem.'
       />

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,17 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        port: '',
+        pathname: '/danuy5rqb/image/upload/**',
+        search: '',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- fetch the top eight builders with TanStack Query through `apiFetch`
- map the verified nested leaderboard payload into `BuilderCardView`
- render responsive cards with loading, empty, and error states
- link the section to the builders directory
- allow the Cloudinary avatar path returned by the live leaderboard

## Verification

- `npm run lint`
- `NEXT_PUBLIC_API_URL=https://stage-api.boundlessfi.xyz npm run build`
- desktop and mobile visual checks

## Runtime note

The staging API currently omits `Access-Control-Allow-Origin` for the Builders origin. The section handles that request failure, but the backend allowlist must include `https://builders.boundlessfi.xyz` for live browser data.

Closes #320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Top builders” section to the landing page, featuring builder cards and links to detailed profiles.
  * Added loading, empty, and error states for leaderboard data.
  * Added a link to browse all builders.

* **Bug Fixes**
  * Enabled secure display of remote builder images hosted on Cloudinary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->