### PR TITLE
feat(landing): add featured projects section

### DIFF
--- a/components/cards/opportunity-card.tsx
+++ b/components/cards/opportunity-card.tsx
@@ -139,29 +139,37 @@ export function OpportunityCard({
           </Meta>
         </div>
 
-        <span aria-hidden className='h-px w-full bg-[#1f2a28]' />
+        {endsIn || reward ? (
+          <>
+            <span aria-hidden className='h-px w-full bg-[#1f2a28]' />
 
-        <div className='flex items-center gap-3'>
-          <span className='flex min-w-0 flex-1 items-center gap-1 text-xs font-medium text-info-500'>
-            <Calendar
-              className='size-4 shrink-0'
-              strokeWidth={1.75}
-              aria-hidden
-            />
-            <span className='truncate'>Ends in {endsIn}</span>
-          </span>
-          <span className='flex shrink-0 items-center gap-2'>
-            <Image
-              src='/currency/usdc.png'
-              alt='Token'
-              width={20}
-              height={20}
-            />
-            <span className='text-xl font-bold tracking-tight whitespace-nowrap text-primary-600'>
-              {reward.amount.toLocaleString()} {reward.currency}
-            </span>
-          </span>
-        </div>
+            <div className='flex items-center gap-3'>
+              {endsIn ? (
+                <span className='flex min-w-0 flex-1 items-center gap-1 text-xs font-medium text-info-500'>
+                  <Calendar
+                    className='size-4 shrink-0'
+                    strokeWidth={1.75}
+                    aria-hidden
+                  />
+                  <span className='truncate'>Ends in {endsIn}</span>
+                </span>
+              ) : null}
+              {reward ? (
+                <span className='ml-auto flex shrink-0 items-center gap-2'>
+                  <Image
+                    src='/currency/usdc.png'
+                    alt='Token'
+                    width={20}
+                    height={20}
+                  />
+                  <span className='text-xl font-bold tracking-tight whitespace-nowrap text-primary-600'>
+                    {reward.amount.toLocaleString()} {reward.currency}
+                  </span>
+                </span>
+              ) : null}
+            </div>
+          </>
+        ) : null}
       </article>
     </Link>
   );

--- a/components/cards/types.ts
+++ b/components/cards/types.ts
@@ -46,9 +46,9 @@ export interface OpportunityCardView {
   /** Sub-mode label or pillar name. Empty string when nothing better is available. */
   mode: string;
   comments: number;
-  /** Pre-formatted countdown like `4D:22H:49M`, or an empty string when no deadline. */
-  endsIn: string;
-  reward: { amount: number; currency: string };
+  /** Pre-formatted countdown like `4D:22H:49M` when a deadline is available. */
+  endsIn?: string;
+  reward?: { amount: number; currency: string };
   /** Detail page path so cards can link out. */
   detailUrl: string;
   isFeatured: boolean;

--- a/components/landing/featured-projects.tsx
+++ b/components/landing/featured-projects.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
+
+import { OpportunityCardSkeleton } from '@/components/cards/opportunity-card-skeleton';
+import { OpportunityCard } from '@/components/cards/opportunity-card';
+import { ArrowRightIcon } from '@/components/icons';
+import { Section, SectionHeading } from '@/components/marketing/section';
+import { Button } from '@/components/ui/button';
+import { apiFetch } from '@/lib/api/client';
+import type { Paginated } from '@/lib/api/types';
+
+import {
+  type FeaturedProjectDto,
+  toProjectCard,
+} from './to-project-card';
+
+const FEATURED_PROJECTS_SKELETON_COUNT = 3;
+
+function useFeaturedProjects() {
+  return useQuery({
+    queryKey: ['projects', 'featured'],
+    queryFn: () =>
+      apiFetch<Paginated<FeaturedProjectDto>>('/projects/featured'),
+  });
+}
+
+function FeaturedProjectsSkeleton() {
+  return (
+    <div className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
+      {Array.from(
+        { length: FEATURED_PROJECTS_SKELETON_COUNT },
+        (_, index) => (
+          <OpportunityCardSkeleton key={index} />
+        )
+      )}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <p className='text-center text-body-sm text-muted-foreground'>
+      No featured projects to show yet.
+    </p>
+  );
+}
+
+export function FeaturedProjects() {
+  const { data, isError, isPending } = useFeaturedProjects();
+  const projects = data?.data.map(toProjectCard) ?? [];
+
+  return (
+    <Section innerClassName='flex flex-col gap-8'>
+      <SectionHeading
+        title='Featured projects'
+        description='Explore standout projects being built across the Boundless ecosystem.'
+      />
+
+      {isPending ? (
+        <FeaturedProjectsSkeleton />
+      ) : isError ? (
+        <p className='text-center text-body-sm text-muted-foreground'>
+          Featured projects could not be loaded right now.
+        </p>
+      ) : projects.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
+          {projects.map((project) => (
+            <OpportunityCard key={project.id} opportunity={project} />
+          ))}
+        </div>
+      )}
+
+      <div className='flex justify-center'>
+        <Button
+          intent='secondary'
+          appearance='outline'
+          size='large'
+          asChild
+        >
+          <Link href='/projects'>
+            Browse all projects
+            <ArrowRightIcon aria-hidden />
+          </Link>
+        </Button>
+      </div>
+    </Section>
+  );
+}

--- a/components/landing/to-project-card.ts
+++ b/components/landing/to-project-card.ts
@@ -65,11 +65,6 @@ export function toProjectCard(
     participants: project.teamMembers.length + 1,
     mode: project.originType ? ORIGIN_LABEL[project.originType] : '',
     comments: project._count.comments,
-    endsIn: '',
-    reward: {
-      amount: 0,
-      currency: '',
-    },
     detailUrl: `/projects/${project.slug ?? project.id}`,
     isFeatured: project.isFeatured,
   };

--- a/components/landing/to-project-card.ts
+++ b/components/landing/to-project-card.ts
@@ -1,0 +1,76 @@
+import type {
+  OpportunityCardStatus,
+  OpportunityCardView,
+} from '@/components/cards/types';
+
+export type ProjectPublicStatus =
+  | 'LIVE'
+  | 'BETA'
+  | 'IN_DEVELOPMENT'
+  | 'ARCHIVED';
+
+export type ProjectOriginType =
+  | 'HACKATHON'
+  | 'GRANT'
+  | 'BOUNTY'
+  | 'CROWDFUNDING'
+  | 'MANUAL';
+
+interface ProjectOwnerDto {
+  name: string | null;
+}
+
+export interface FeaturedProjectDto {
+  id: string;
+  title: string;
+  category: string | null;
+  slug: string | null;
+  publicStatus: ProjectPublicStatus;
+  originType: ProjectOriginType | null;
+  isFeatured: boolean;
+  teamMembers: unknown[];
+  creator: ProjectOwnerDto;
+  organization: ProjectOwnerDto | null;
+  _count: {
+    comments: number;
+  };
+}
+
+const PROJECT_STATUS: Record<ProjectPublicStatus, OpportunityCardStatus> = {
+  LIVE: 'open',
+  BETA: 'in_progress',
+  IN_DEVELOPMENT: 'in_progress',
+  ARCHIVED: 'completed',
+};
+
+const ORIGIN_LABEL: Record<ProjectOriginType, string> = {
+  HACKATHON: 'Hackathon',
+  GRANT: 'Grant',
+  BOUNTY: 'Bounty',
+  CROWDFUNDING: 'Crowdfunding',
+  MANUAL: 'Manual',
+};
+
+export function toProjectCard(
+  project: FeaturedProjectDto,
+  index: number
+): OpportunityCardView {
+  return {
+    id: project.id,
+    org: project.organization?.name ?? project.creator?.name ?? '',
+    index: index + 1,
+    status: PROJECT_STATUS[project.publicStatus],
+    title: project.title,
+    category: project.category ?? 'Uncategorized',
+    participants: project.teamMembers.length + 1,
+    mode: project.originType ? ORIGIN_LABEL[project.originType] : '',
+    comments: project._count.comments,
+    endsIn: '',
+    reward: {
+      amount: 0,
+      currency: '',
+    },
+    detailUrl: `/projects/${project.slug ?? project.id}`,
+    isFeatured: project.isFeatured,
+  };
+}


### PR DESCRIPTION
## Summary

- fetch featured projects with TanStack Query through `apiFetch`
- map project data into `OpportunityCardView` and render the existing cards
- handle loading, error, and empty states with a link to `/projects`

## Verification

- `npm run lint`
- `NEXT_PUBLIC_API_URL=https://stage-api.boundlessfi.xyz npm run build`

Closes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a featured projects section to the landing page.
  - Displays project cards in a responsive grid with status, participation, and project details.
  - Added loading, error, and empty-state messaging.
  - Added a “Browse all projects” link for exploring the full project directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->