### PR TITLE
feat(about): add What you'll find section

### DIFF
--- a/components/about/what-youll-find.tsx
+++ b/components/about/what-youll-find.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import type { ComponentType, SVGProps } from 'react';
 
-import { BoxIcon, CodeIcon, UsersIcon } from '@/components/icons';
+import { BoxIcon, UserGroupIcon, UsersIcon } from '@/components/icons';
 import { Section, SectionHeading } from '@/components/marketing/section';
 import { cn } from '@/lib/utils';
 
@@ -16,7 +16,7 @@ type Pillar = {
 
 const PILLARS: Pillar[] = [
   {
-    icon: CodeIcon,
+    icon: UsersIcon,
     title: 'Builders',
     description:
       "Developers, designers, and product leaders from across the network, each with a profile of what they've shipped.",
@@ -30,7 +30,7 @@ const PILLARS: Pillar[] = [
     href: '/projects',
   },
   {
-    icon: UsersIcon,
+    icon: UserGroupIcon,
     title: 'Teams',
     description:
       'The organizations turning ideas into shipped work, and the people who make them up.',

--- a/components/about/what-youll-find.tsx
+++ b/components/about/what-youll-find.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link';
+import type { ComponentType, SVGProps } from 'react';
+
+import { BoxIcon, CodeIcon, UsersIcon } from '@/components/icons';
+import { Section, SectionHeading } from '@/components/marketing/section';
+import { cn } from '@/lib/utils';
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+type Pillar = {
+  icon: IconComponent;
+  title: string;
+  description: string;
+  href: '/builders' | '/projects' | '/teams';
+};
+
+const PILLARS: Pillar[] = [
+  {
+    icon: CodeIcon,
+    title: 'Builders',
+    description:
+      "Developers, designers, and product leaders from across the network, each with a profile of what they've shipped.",
+    href: '/builders',
+  },
+  {
+    icon: BoxIcon,
+    title: 'Projects',
+    description:
+      'The products being built, launched, and funded on Boundless, with the teams behind them.',
+    href: '/projects',
+  },
+  {
+    icon: UsersIcon,
+    title: 'Teams',
+    description:
+      'The organizations turning ideas into shipped work, and the people who make them up.',
+    href: '/teams',
+  },
+];
+
+/**
+ * Equal-weight directory pillar card. Mirrors the Boundless pillar pattern
+ * (icon, bold title, short description, subtle hover) as a link into a
+ * directory route. Distinct from the animated marketing PillarCard.
+ */
+function DirectoryPillarCard({
+  icon: Icon,
+  title,
+  description,
+  href,
+}: Pillar) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'flex h-full flex-col gap-4 rounded-2xl border border-border bg-card p-6',
+        'transition-[border-color,background-color] duration-200',
+        'hover:border-neutral-500 hover:bg-ink',
+        'focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:outline-none',
+        'motion-reduce:transition-none'
+      )}
+    >
+      <span className='flex size-10 items-center justify-center rounded-xl bg-primary-500/8 text-primary-500'>
+        <Icon className='size-5' aria-hidden />
+      </span>
+      <div className='flex flex-col gap-2'>
+        <h3 className='font-heading text-h5 font-semibold text-foreground'>
+          {title}
+        </h3>
+        <p className='text-body-sm text-muted-foreground'>{description}</p>
+      </div>
+    </Link>
+  );
+}
+
+/** About-page section introducing the three directory pillars. Static content. */
+export function WhatYoullFind() {
+  return (
+    <Section innerClassName='flex flex-col gap-8'>
+      <SectionHeading
+        eyebrow="What you'll find"
+        title='One place to explore the whole ecosystem.'
+        description='Browse the directory by what matters to you.'
+      />
+
+      <div className='grid grid-cols-1 gap-4 lg:grid-cols-3'>
+        {PILLARS.map(pillar => (
+          <DirectoryPillarCard key={pillar.href} {...pillar} />
+        ))}
+      </div>
+
+      <p className='mx-auto max-w-2xl text-center text-body-sm text-muted-foreground'>
+        This is a showcase. Everything here is created and maintained in the
+        main Boundless app. Here, you explore and discover.
+      </p>
+    </Section>
+  );
+}


### PR DESCRIPTION
Closes #332 

<img width="1858" height="1436" alt="image" src="https://github.com/user-attachments/assets/5b1f88b4-ed47-4452-9136-7273318a99b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new About-page section with three directory entry cards for **Builders**, **Projects**, and **Teams**.
  * Each card includes an icon, title, brief description, and navigates to the relevant directory.
  * Improved usability with consistent styling plus hover and keyboard focus states.
  * Added a centered paragraph beneath the directory cards to provide additional context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->