### PR TITLE
feat(landing): add WantToBuild CTA band section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # boundless-nestjs backend origin. All routes are served under /api.
 NEXT_PUBLIC_API_URL="https://stage-api.boundlessfi.xyz"
+
+# Main Boundless application. Used for outbound links (e.g. the CTA band).
+NEXT_PUBLIC_BOUNDLESS_APP_URL="https://boundlessfi.xyz"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button';
 import { HeroBackground } from '@/components/marketing/hero-background';
 import { Section } from '@/components/marketing/section';
 
+import { WantToBuild } from '@/components/landing/want-to-build';
+
 export default function Home() {
   return (
     <>
@@ -33,6 +35,8 @@ export default function Home() {
           </div>
         </Section>
       </HeroBackground>
+
+      <WantToBuild />
 
       <SiteFooter />
     </>

--- a/components/landing/want-to-build.tsx
+++ b/components/landing/want-to-build.tsx
@@ -8,7 +8,7 @@ export function WantToBuild() {
       action={{
         label: 'Get started on Boundless',
         href:
-          process.env.NEXT_PUBLIC_BOUNDLESS_APP_URL ??
+          process.env.NEXT_PUBLIC_BOUNDLESS_APP_URL?.trim() ||
           'https://boundlessfi.xyz',
         external: true,
       }}

--- a/components/landing/want-to-build.tsx
+++ b/components/landing/want-to-build.tsx
@@ -1,0 +1,17 @@
+import { CtaBand } from '@/components/marketing/cta-band';
+
+export function WantToBuild() {
+  return (
+    <CtaBand
+      heading='Want to be a builder?'
+      description='Create your profile, join a team, and start shipping on Boundless. Your work belongs in the showcase.'
+      action={{
+        label: 'Get started on Boundless',
+        href:
+          process.env.NEXT_PUBLIC_BOUNDLESS_APP_URL ??
+          'https://boundlessfi.xyz',
+        external: true,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Description
 
Adds the "Want to be a builder?" CTA band to the landing page, inviting visitors to join the main Boundless app.
 
### Changes
 
- **`components/landing/want-to-build.tsx`** — New landing section that renders the reusable `CtaBand` component with exact copy from the spec:
  - Heading: "Want to be a builder?"
  - Description: "Create your profile, join a team, and start shipping on Boundless. Your work belongs in the showcase."
  - Action button: "Get started on Boundless" → links to `NEXT_PUBLIC_BOUNDLESS_APP_URL` (defaults to `https://boundlessfi.xyz`), opens in a new tab
- **`.env.example`** — Added `NEXT_PUBLIC_BOUNDLESS_APP_URL` with default `https://boundlessfi.xyz`
- **`app/page.tsx`** — Composed `<WantToBuild />` between the hero section and `SiteFooter`
 
### Verification
 
- [x] `npm run lint` passes
- [x] `npm run build` passes
- No hand-rolled CTA/button — fully reuses `components/marketing/cta-band.tsx`
- Copy lives in the caller (not baked into `CtaBand`) so About page (#333) stays independent
 
Closes #323

## Visuals 
<img width="1332" height="519" alt="Screenshot 2026-07-26 at 22 38 54" src="https://github.com/user-attachments/assets/759c74ad-0af4-4766-b10d-5bc82d7f4916" />
<img width="384" height="352" alt="Screenshot 2026-07-26 at 22 41 12" src="https://github.com/user-attachments/assets/e4c7a9e5-dd7f-4f35-8eb1-65dd9d8c110b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Want to build?” call-to-action section to the home page.
  - The CTA links visitors to the external Boundless app, with a default fallback link when no custom URL is configured.
- **Configuration**
  - Added an environment setting to customize the outbound Boundless app link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->