### PR TITLE
feat(about): compose about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,12 +1,28 @@
+import { AboutHero } from '@/components/about/about-hero';
+import { WhatYoullFind } from '@/components/about/what-youll-find';
+import { WhyWeBuiltThis } from '@/components/about/why-we-built-this';
 import { SiteFooter } from '@/components/layout/site-footer';
 import { SiteHeader } from '@/components/layout/site-header';
-import { AboutHero } from '@/components/about/about-hero';
+import { CtaBand } from '@/components/marketing/cta-band';
 
 export default function AboutPage() {
   return (
     <>
       <SiteHeader />
       <AboutHero />
+      <WhyWeBuiltThis />
+      <WhatYoullFind />
+      <CtaBand
+        heading='Want to be a builder?'
+        description='Create your profile, join a team, and start shipping on Boundless. Your work belongs in the showcase.'
+        action={{
+          label: 'Get started on Boundless',
+          href:
+            process.env.NEXT_PUBLIC_BOUNDLESS_APP_URL ??
+            'https://boundlessfi.xyz',
+          external: true,
+        }}
+      />
       <SiteFooter />
     </>
   );


### PR DESCRIPTION
## Summary

- compose the `/about` route from the existing About sections
- add the reusable CTA band with the configured Boundless app URL

## Testing

- `npm run lint`
- `npm run build`

## Screenshot

<img width="1263" height="2960" alt="issue-333-about-page" src="https://github.com/user-attachments/assets/bb7bfaa5-7e5e-48e3-a7f2-bfa779bc7f40" />

Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the About page with sections explaining the product’s motivation and what visitors can find.
  * Added a call-to-action that links visitors to the external application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->