### PR TITLE
feat(landing): add ecosystem stats strip

### DIFF
--- a/components/landing/stats-strip.tsx
+++ b/components/landing/stats-strip.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useQueries } from '@tanstack/react-query';
+
+import { Section } from '@/components/marketing/section';
+import { Skeleton } from '@/components/ui/skeleton';
+import { StatsBar, type StatItem } from '@/components/ui/stats-bar';
+import { apiFetch } from '@/lib/api/client';
+import type { Paginated } from '@/lib/api/types';
+
+const STATS = [
+  {
+    label: 'Builders',
+    path: '/users/directory?limit=1',
+    queryKey: ['ecosystem-stats', 'builders'],
+  },
+  {
+    label: 'Projects',
+    path: '/projects?limit=1',
+    queryKey: ['ecosystem-stats', 'projects'],
+  },
+  {
+    label: 'Teams',
+    path: '/organizations?limit=1',
+    queryKey: ['ecosystem-stats', 'teams'],
+  },
+] as const;
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+function NumberSkeleton({ mobile = false }: { mobile?: boolean }) {
+  return (
+    <Skeleton
+      aria-hidden
+      className={mobile ? 'h-5 w-10' : 'h-9 w-16'}
+    />
+  );
+}
+
+async function fetchTotal(path: string) {
+  const response = await apiFetch<Paginated<unknown>>(path);
+  return response.pagination.total;
+}
+
+function useEcosystemStats() {
+  return useQueries({
+    queries: STATS.map(stat => ({
+      queryKey: stat.queryKey,
+      queryFn: () => fetchTotal(stat.path),
+    })),
+  });
+}
+
+export function StatsStrip() {
+  const queries = useEcosystemStats();
+  const items = queries.flatMap((query, index): StatItem[] => {
+    const stat = STATS[index];
+
+    if (query.isPending) {
+      return [
+        {
+          label: stat.label,
+          value: <NumberSkeleton />,
+          mobileValue: <NumberSkeleton mobile />,
+        },
+      ];
+    }
+
+    if (
+      query.isError ||
+      typeof query.data !== 'number' ||
+      !Number.isFinite(query.data)
+    ) {
+      return [];
+    }
+
+    const value = numberFormatter.format(query.data);
+
+    return [{ label: stat.label, value }];
+  });
+
+  if (items.length === 0) return null;
+
+  return (
+    <Section>
+      <StatsBar items={items} />
+    </Section>
+  );
+}


### PR DESCRIPTION
## Summary

- add the ecosystem stats strip with builders, projects, and teams totals
- fetch all three counts in parallel and hide unavailable stats gracefully
- reuse the shared StatsBar, Section, and Skeleton components

## Testing

- `npm run lint`
- `npm run build`

## Screenshot

<img width="1280" height="2113" alt="issue-322-stats-strip" src="https://github.com/user-attachments/assets/0f60271b-0d2a-48a3-ad19-3bafbf6a2c08" />

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an ecosystem statistics bar displaying totals for builders, projects, and teams.
  * Statistics load concurrently and show responsive loading placeholders while data is being retrieved.
  * Valid totals are formatted for readability, while unavailable statistics are automatically omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->