### PR TITLE
fix(landing): blend hero into the CTA band

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
     <>
       <SiteHeader />
 
-      <HeroBackground fieldHeight={640} fadeBottom>
+      <HeroBackground fieldHeight={640}>
         <Section className='py-24 text-center lg:py-32'>
           <div className='inline-flex items-center rounded-full border border-white/10 bg-white/5 p-1 text-body-xs text-white/70'>
             <span className='rounded-full bg-white/10 px-3 py-1 font-medium text-white'>


### PR DESCRIPTION
The landing hero used `fadeBottom`, which resolves its gradient to solid ink at the bottom, but the CTA band below it starts with a teal glow. That produced a visible dark-then-glow seam between them.

This drops `fadeBottom` so the hero ends on the same teal tint (`rgba(46,237,170,0.08)`) that the CTA begins with, merging the two glows into one continuous blend.

`fadeBottom` was correct when the hero sat directly above the ink footer; the CTA now sits between them.

> Note: when #324 composes the full landing (inserting stats / top-builders / featured between the hero and the CTA), the hero-to-first-section gradient handoff will need another pass, since the stats strip has a plain ink background. This fixes the currently live composition (hero -> CTA -> footer).

Verified: `npm run lint` and `npm run build` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the home page hero background rendering for a cleaner visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->