### PR TITLE
fix(landing): fade the CTA in place to avoid background shift

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,10 @@ export default function Home() {
       <Reveal>
         <FeaturedProjects />
       </Reveal>
-      <Reveal>
+      {/* y=0: the CTA Section has a full-width background gradient, so a
+          translateY reveal would shift the whole background and leave a gap
+          above it until the animation settles. Fade in place instead. */}
+      <Reveal y={0}>
         <WantToBuild />
       </Reveal>
 


### PR DESCRIPTION
Final cleanup after the landing composition (#328) landed.

The `WantToBuild` CTA uses `CtaBand`, whose `Section` has a full-width background gradient. Wrapping it in a default `<Reveal>` (which applies a `translateY`) shifts that whole background on scroll-in and leaves a visible gap above the section until the animation settles.

This switches the CTA to `<Reveal y={0}>` so it fades in place. The other three sections have transparent `Section`s, so they keep their upward slide.

Verified: `npm run lint` and `npm run build` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CTA section’s fade-in animation to prevent visible gaps or unwanted background movement during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->