### PR TITLE
style(landing): boundless-style titles, section blends, reveal, and Launch App

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,6 @@ import {
 import { SiteFooter } from '@/components/layout/site-footer';
 import { SiteHeader } from '@/components/layout/site-header';
 import { HeroBackground } from '@/components/marketing/hero-background';
-import { Reveal } from '@/components/marketing/reveal';
 import { Section } from '@/components/marketing/section';
 import { Button } from '@/components/ui/button';
 
@@ -16,7 +15,7 @@ export default function Home() {
     <>
       <SiteHeader />
 
-      <HeroBackground fieldHeight={640} fadeBottom>
+      <HeroBackground fieldHeight={640}>
         <Section className='py-24 text-center lg:py-32'>
           <div className='inline-flex items-center rounded-full border border-white/10 bg-white/5 p-1 text-body-xs text-white/70'>
             <span className='rounded-full bg-white/10 px-3 py-1 font-medium text-white'>
@@ -41,18 +40,10 @@ export default function Home() {
         </Section>
       </HeroBackground>
 
-      <Reveal>
-        <StatsStrip />
-      </Reveal>
-      <Reveal>
-        <TopBuilders />
-      </Reveal>
-      <Reveal>
-        <FeaturedProjects />
-      </Reveal>
-      <Reveal>
-        <WantToBuild />
-      </Reveal>
+      <StatsStrip />
+      <TopBuilders />
+      <FeaturedProjects />
+      <WantToBuild />
 
       <SiteFooter />
     </>

--- a/components/landing/featured-projects.tsx
+++ b/components/landing/featured-projects.tsx
@@ -52,10 +52,16 @@ export function FeaturedProjects() {
   const projects = data?.data.map(toProjectCard) ?? [];
 
   return (
-    <Section innerClassName='flex flex-col gap-8'>
+    <Section
+      reveal
+      className='bg-[linear-gradient(180deg,rgba(13,17,17,0)_50%,rgba(46,237,170,0.08)_100%)]'
+      innerClassName='flex flex-col gap-8'
+    >
       <SectionHeading
+        align='left'
         title='Featured projects'
         description='Explore standout projects being built across the Boundless ecosystem.'
+        titleClassName='leading-none font-semibold lg:text-5xl lg:tracking-[-1.92px]'
       />
 
       {isPending ? (

--- a/components/landing/stats-strip.tsx
+++ b/components/landing/stats-strip.tsx
@@ -82,7 +82,10 @@ export function StatsStrip() {
   if (items.length === 0) return null;
 
   return (
-    <Section>
+    <Section
+      reveal
+      className='bg-[linear-gradient(180deg,rgba(46,237,170,0.08)_0%,rgba(13,17,17,0)_100%)]'
+    >
       <StatsBar items={items} />
     </Section>
   );

--- a/components/landing/top-builders.tsx
+++ b/components/landing/top-builders.tsx
@@ -50,10 +50,12 @@ export function TopBuilders() {
   const builders = data?.entries.map(toBuilderCard) ?? [];
 
   return (
-    <Section innerClassName='flex flex-col gap-8'>
+    <Section reveal innerClassName='flex flex-col gap-8'>
       <SectionHeading
+        align='left'
         title='Top builders'
         description='Meet the builders making an impact across the Boundless ecosystem.'
+        titleClassName='leading-none font-semibold lg:text-5xl lg:tracking-[-1.92px]'
       />
 
       {isPending ? (

--- a/components/layout/site-header.tsx
+++ b/components/layout/site-header.tsx
@@ -15,6 +15,10 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { headerMenus } from '@/config/marketing-nav';
 
+/** The main Boundless app, where builders sign up and create. Opens in a new tab. */
+const LAUNCH_APP_URL =
+  process.env.NEXT_PUBLIC_BOUNDLESS_APP_URL ?? 'https://boundlessfi.xyz';
+
 type HeaderVariant = 'site' | 'blog';
 
 function NavDivider() {
@@ -178,9 +182,14 @@ function MobileMenu({ onNavigate }: { onNavigate: () => void }) {
           </div>
         ))}
         <PillButton asChild className='w-full'>
-          <Link href='/for-you' onClick={onNavigate}>
+          <a
+            href={LAUNCH_APP_URL}
+            target='_blank'
+            rel='noopener noreferrer'
+            onClick={onNavigate}
+          >
             Launch App
-          </Link>
+          </a>
         </PillButton>
       </div>
     </div>
@@ -214,7 +223,9 @@ export function SiteHeader() {
               <PillButton type='button'>Subscribe</PillButton>
             ) : (
               <PillButton asChild>
-                <Link href='/for-you'>Launch App</Link>
+                <a href={LAUNCH_APP_URL} target='_blank' rel='noopener noreferrer'>
+                  Launch App
+                </a>
               </PillButton>
             )}
           </div>
@@ -230,7 +241,13 @@ export function SiteHeader() {
             ) : (
               <>
                 <PillButton asChild>
-                  <Link href='/for-you'>Launch App</Link>
+                  <a
+                    href={LAUNCH_APP_URL}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                  >
+                    Launch App
+                  </a>
                 </PillButton>
                 <button
                   type='button'

--- a/components/marketing/cta-band.tsx
+++ b/components/marketing/cta-band.tsx
@@ -45,6 +45,7 @@ export function CtaBand({
 
   return (
     <Section
+      reveal
       className={cn(
         'bg-ink bg-[linear-gradient(180deg,rgba(46,237,170,0.08)_0%,rgba(13,17,17,0)_50%)]',
         className

--- a/components/marketing/reveal.tsx
+++ b/components/marketing/reveal.tsx
@@ -10,17 +10,23 @@ interface RevealProps {
   className?: string;
   /** Seconds to delay the animation; use `index * step` for a stagger. */
   delay?: number;
+  /** Horizontal travel distance in px. */
+  x?: number;
   /** Vertical travel distance in px. */
   y?: number;
+  /** Animation duration in seconds. */
+  duration?: number;
   as?: keyof typeof MOTION;
 }
 
-/** Fades and slides its children up once they scroll into view. */
+/** Fades and slides its children into place once they scroll into view. */
 export function Reveal({
   children,
   className,
   delay = 0,
+  x = 0,
   y = 32,
+  duration = 1.1,
   as = 'div',
 }: RevealProps) {
   const reduceMotion = useReducedMotion();
@@ -34,10 +40,10 @@ export function Reveal({
   return (
     <Tag
       className={className}
-      initial={{ opacity: 0, y }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial={{ opacity: 0, x, y }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
       viewport={{ once: true, amount: 0.2 }}
-      transition={{ duration: 1.1, delay, ease: [0.16, 1, 0.3, 1] }}
+      transition={{ duration, delay, ease: [0.16, 1, 0.3, 1] }}
     >
       {children}
     </Tag>

--- a/components/marketing/section.tsx
+++ b/components/marketing/section.tsx
@@ -1,26 +1,54 @@
 import { cn } from '@/lib/utils';
 
+import { Reveal } from './reveal';
+
 /** Centered max-width container with vertical rhythm for a marketing section. */
 export function Section({
   id,
   className,
   innerClassName,
+  reveal = false,
+  revealFrom = 'up',
   children,
 }: {
   id?: string;
   className?: string;
   innerClassName?: string;
+  /**
+   * Animate the inner content column in on scroll (fade + slide). The animation
+   * lives on the centered content, not the full-width `<section>`, so the
+   * background stays put and no empty gap appears above the section. Honors
+   * reduced motion.
+   */
+  reveal?: boolean;
+  /** Which edge the content slides in from when `reveal` is set. */
+  revealFrom?: 'left' | 'right' | 'up';
   children: React.ReactNode;
 }) {
   // 8pt grid: 64px/20px vertical/horizontal on mobile, 80px/100px on desktop.
+  const innerClass = cn('mx-auto w-full max-w-page', innerClassName);
+  const offset =
+    revealFrom === 'up'
+      ? { x: 0, y: 48 }
+      : { x: revealFrom === 'right' ? 64 : -64, y: 0 };
+
   return (
     <section
       id={id}
-      className={cn('px-5 py-16 lg:px-[100px] lg:py-20', className)}
+      // Clip a horizontal slide so it never spills into a page scrollbar.
+      className={cn(
+        'px-5 py-16 lg:px-[100px] lg:py-20',
+        reveal && 'overflow-x-clip',
+        className
+      )}
     >
-      <div className={cn('mx-auto w-full max-w-page', innerClassName)}>
-        {children}
-      </div>
+      {reveal ? (
+        <Reveal className={innerClass} x={offset.x} y={offset.y} duration={2.1}>
+          {children}
+        </Reveal>
+      ) : (
+        <div className={innerClass}>{children}</div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Landing-page polish to match boundless-platform.

**Titles** — left-align the Top builders / Featured projects section titles and match the larger display scale (per-call, no shared-default change).

**Section blends** — give the sections subtle teal gradients so the glow flows continuously (hero -> stats -> ... -> CTA) instead of a flat dark mid-page block. Drops the hero `fadeBottom` so its glow meets the first section.

**Reveal on content, not sections** — add a `reveal` prop to `Section` (and `x`/`duration` to `Reveal`) that animates the inner content column, so the background stays put and no empty gap appears above each section on scroll-in. Removes the page-level `<Reveal>` wrappers. Supersedes #343.

**Header** — the Launch App CTA now opens the main Boundless app in a new tab (was a dead `/for-you` route).

Verified: `npm run lint` and `npm run build` pass.