### PR TITLE
refactor(about): align the About page with boundless-platform

### DIFF
--- a/components/about/about-hero.tsx
+++ b/components/about/about-hero.tsx
@@ -8,7 +8,7 @@ import { PartnerLogos } from '@/components/marketing/partner-logos';
  */
 export function AboutHero() {
   return (
-    <HeroSection partners={<PartnerLogos />} fadeBottom className='pt-16 lg:pt-36'>
+    <HeroSection partners={<PartnerLogos />} className='pt-16 lg:pt-36'>
       <h1 className='font-heading text-5xl leading-none font-semibold tracking-tight sm:text-6xl lg:text-[72px] lg:tracking-[-4px]'>
         <span className='text-white'>Meet the People </span>
         <span className='text-primary'>Building the Future</span>

--- a/components/about/what-youll-find.tsx
+++ b/components/about/what-youll-find.tsx
@@ -1,98 +1,35 @@
-import Link from 'next/link';
-import type { ComponentType, SVGProps } from 'react';
+import { FeatureListSection } from '@/components/marketing/feature-list-section';
 
-import { BoxIcon, UserGroupIcon, UsersIcon } from '@/components/icons';
-import { Section, SectionHeading } from '@/components/marketing/section';
-import { cn } from '@/lib/utils';
-
-type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
-
-type Pillar = {
-  icon: IconComponent;
-  title: string;
-  description: string;
-  href: '/builders' | '/projects' | '/teams';
-};
-
-const PILLARS: Pillar[] = [
+const ITEMS = [
   {
-    icon: UsersIcon,
     title: 'Builders',
     description:
       "Developers, designers, and product leaders from across the network, each with a profile of what they've shipped.",
-    href: '/builders',
   },
   {
-    icon: BoxIcon,
     title: 'Projects',
     description:
       'The products being built, launched, and funded on Boundless, with the teams behind them.',
-    href: '/projects',
   },
   {
-    icon: UserGroupIcon,
     title: 'Teams',
     description:
       'The organizations turning ideas into shipped work, and the people who make them up.',
-    href: '/teams',
   },
 ];
 
 /**
- * Equal-weight directory pillar card. Mirrors the Boundless pillar pattern
- * (icon, bold title, short description, subtle hover) as a link into a
- * directory route. Distinct from the animated marketing PillarCard.
+ * About-page section introducing the three things you can explore. Uses the
+ * two-column feature-list layout (purple eyebrow + heading on the left, a
+ * dash-separated list on the right), mirroring the boundless-platform About
+ * mission section.
  */
-function DirectoryPillarCard({
-  icon: Icon,
-  title,
-  description,
-  href,
-}: Pillar) {
-  return (
-    <Link
-      href={href}
-      className={cn(
-        'flex h-full flex-col gap-4 rounded-2xl border border-border bg-card p-6',
-        'transition-[border-color,background-color] duration-200',
-        'hover:border-neutral-500 hover:bg-ink',
-        'focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:outline-none',
-        'motion-reduce:transition-none'
-      )}
-    >
-      <span className='flex size-10 items-center justify-center rounded-xl bg-primary-500/8 text-primary-500'>
-        <Icon className='size-5' aria-hidden />
-      </span>
-      <div className='flex flex-col gap-2'>
-        <h3 className='font-heading text-h5 font-semibold text-foreground'>
-          {title}
-        </h3>
-        <p className='text-body-sm text-muted-foreground'>{description}</p>
-      </div>
-    </Link>
-  );
-}
-
-/** About-page section introducing the three directory pillars. Static content. */
 export function WhatYoullFind() {
   return (
-    <Section innerClassName='flex flex-col gap-8'>
-      <SectionHeading
-        eyebrow="What you'll find"
-        title='One place to explore the whole ecosystem.'
-        description='Browse the directory by what matters to you.'
-      />
-
-      <div className='grid grid-cols-1 gap-4 lg:grid-cols-3'>
-        {PILLARS.map(pillar => (
-          <DirectoryPillarCard key={pillar.href} {...pillar} />
-        ))}
-      </div>
-
-      <p className='mx-auto max-w-2xl text-center text-body-sm text-muted-foreground'>
-        This is a showcase. Everything here is created and maintained in the
-        main Boundless app. Here, you explore and discover.
-      </p>
-    </Section>
+    <FeatureListSection
+      eyebrow="What you'll find"
+      title='One place to explore the whole ecosystem.'
+      items={ITEMS}
+    />
   );
 }

--- a/components/about/why-we-built-this.tsx
+++ b/components/about/why-we-built-this.tsx
@@ -1,7 +1,13 @@
 import type { ComponentType, SVGProps } from 'react';
 
 import { EyeIcon, SearchIcon, TrophyIcon } from '@/components/icons';
-import { Section, SectionHeading } from '@/components/marketing/section';
+import { Reveal } from '@/components/marketing/reveal';
+import { Section } from '@/components/marketing/section';
+
+// Mint glow at the top, fading fully to dark so it merges into the section
+// below (mirrors the boundless-platform About intro).
+const GLOW =
+  'linear-gradient(180deg, rgba(46, 237, 170, 0.08) 0%, rgba(13, 17, 17, 0.00) 100%), #0D1111';
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
@@ -32,10 +38,10 @@ const VALUE_POINTS: ValuePoint[] = [
   },
 ];
 
-/** Single value point: tinted icon square, bold title, muted one-line description. */
-function ValuePointItem({ icon: Icon, title, description }: ValuePoint) {
+/** Bordered value card: tinted icon square, bold title, muted description. */
+function ValueCard({ icon: Icon, title, description }: ValuePoint) {
   return (
-    <div className='flex flex-col gap-3'>
+    <div className='flex h-full flex-col gap-4 rounded-2xl border border-border bg-card p-6'>
       <span className='flex size-10 items-center justify-center rounded-xl bg-primary-500/8 text-primary-500'>
         <Icon className='size-5' aria-hidden />
       </span>
@@ -49,21 +55,46 @@ function ValuePointItem({ icon: Icon, title, description }: ValuePoint) {
   );
 }
 
-/** About-page mission section: why the builders directory exists. Static content. */
+/**
+ * About-page mission section: why the builders directory exists. Two-column
+ * intro (purple eyebrow + heading on the left, copy on the right) over a top
+ * glow, then the value points as bordered cards.
+ */
 export function WhyWeBuiltThis() {
   return (
-    <Section innerClassName='flex flex-col gap-8'>
-      <SectionHeading
-        eyebrow='Why we built this'
-        title='Great products are easy to find. The people who build them are not.'
-        description="Every project on Boundless represents months of work by developers, designers, and founders. But while the products get attention, the people behind them often stay invisible. We built this directory to change that: a home where the ecosystem's builders can be discovered, followed, and celebrated for what they ship."
-      />
+    <div style={{ background: GLOW }}>
+      <Section innerClassName='flex flex-col gap-12'>
+        <div className='flex flex-col gap-8 lg:flex-row lg:gap-[200px]'>
+          <Reveal className='flex flex-col gap-3 lg:w-[380px] lg:shrink-0'>
+            <p className='font-sans text-body-xs font-semibold text-primary lg:text-body lg:text-[#cebef9]'>
+              Why we built this
+            </p>
+            <h2 className='font-heading text-h2 font-semibold text-white lg:text-display-sm'>
+              Great products are easy to find. The people who build them are
+              not.
+            </h2>
+          </Reveal>
 
-      <div className='grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-6'>
-        {VALUE_POINTS.map(point => (
-          <ValuePointItem key={point.title} {...point} />
-        ))}
-      </div>
-    </Section>
+          <Reveal delay={0.2} className='flex-1'>
+            <p className='text-body-lg text-white/70'>
+              Every project on Boundless represents months of work by
+              developers, designers, and founders. But while the products get
+              attention, the people behind them often stay invisible. We built
+              this directory to change that: a home where the ecosystem&rsquo;s
+              builders can be discovered, followed, and celebrated for what they
+              ship.
+            </p>
+          </Reveal>
+        </div>
+
+        <div className='grid grid-cols-1 gap-4 lg:grid-cols-3'>
+          {VALUE_POINTS.map((point, index) => (
+            <Reveal key={point.title} delay={index * 0.1}>
+              <ValueCard {...point} />
+            </Reveal>
+          ))}
+        </div>
+      </Section>
+    </div>
   );
 }


### PR DESCRIPTION
Cleans up the About page to mirror how boundless-platform builds its About sections.

### Changes
- **Two-column mission with purple eyebrow.** `Why we built this` now uses the boundless two-column layout: a purple (`#cebef9`) eyebrow + heading on the left, copy on the right, over a top-glow gradient.
- **Bordered cards.** The value points (Visibility / Discovery / Recognition) were borderless; they are now bordered cards (`border-border bg-card`).
- **Converted a card section to another structure.** `What you'll find` was three pillar cards; it now uses the shared `FeatureListSection` (two-column, purple eyebrow + heading left, dash-separated Builders/Projects/Teams list right, bottom glow).
- **Blend.** Sections carry glow gradients that flow into each other (hero teal -> mission top-glow -> feature-list bottom-glow -> CTA). Removed `fadeBottom` from the About hero so its glow meets the first section.

Independent of the landing-polish PR (#344). Verified: `npm run lint` and `npm run build` pass; `/about` prerenders.

Preview: `/about`.