### PR TITLE
chore: port discover filter/toolbar components for the projects page

### DIFF
--- a/components/discover/category-tabs.tsx
+++ b/components/discover/category-tabs.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export function CategoryTabs({
+  categories,
+  active,
+  onSelect,
+}: {
+  categories: readonly string[];
+  active: string;
+  onSelect: (category: string) => void;
+}) {
+  return (
+    <div className='flex items-center gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-visible'>
+      {categories.map(category => {
+        const isActive = category === active;
+        return (
+          <Button
+            key={category}
+            appearance={isActive ? 'solid' : 'outline'}
+            intent={isActive ? 'primary' : 'secondary'}
+            shape='pill'
+            size='small'
+            aria-pressed={isActive}
+            onClick={() => onSelect(category)}
+            className='shrink-0'
+          >
+            {category}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/discover/discover-header.tsx
+++ b/components/discover/discover-header.tsx
@@ -1,0 +1,53 @@
+import { Bookmark, Users } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+/** Page header for a discovery view: title with result count, subtext, actions. */
+export function DiscoverHeader({
+  heading,
+  subtext,
+  count,
+}: {
+  heading: string;
+  subtext: string;
+  count?: number;
+}) {
+  return (
+    <div className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
+      <div className='flex flex-col gap-1'>
+        <h1 className='text-2xl font-semibold tracking-tight text-foreground sm:text-[32px]'>
+          {heading}
+          {typeof count === 'number' ? (
+            <span className='font-normal text-muted-foreground'>
+              {' '}
+              ({count})
+            </span>
+          ) : null}
+        </h1>
+        <p className='text-sm text-muted-foreground'>{subtext}</p>
+      </div>
+      <div className='hidden items-center gap-3 sm:flex'>
+        <Button
+          appearance='outline'
+          intent='secondary'
+          shape='pill'
+          size='small'
+          aria-pressed='true'
+        >
+          <Bookmark className='size-4' strokeWidth={1.75} aria-hidden />
+          Bookmarks
+        </Button>
+        <Button
+          appearance='solid'
+          intent='white'
+          shape='pill'
+          size='small'
+          aria-pressed='true'
+        >
+          <Users className='size-4' strokeWidth={1.75} aria-hidden />
+          Leaderboard
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/discover/discover-toolbar.tsx
+++ b/components/discover/discover-toolbar.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import {
+  ArrowDownUp,
+  Funnel,
+  ListFilter,
+  MoveLeft,
+  RotateCcw,
+  Search,
+} from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+
+import { Button } from '@/components/ui/button';
+import { transitions } from '@/lib/motion';
+
+export function DiscoverToolbar({
+  filtersOpen,
+  onToggleFilters,
+  onOpenMobileFilters,
+  filtersActive,
+  onReset,
+  query,
+  onQueryChange,
+}: {
+  filtersOpen: boolean;
+  onToggleFilters: () => void;
+  onOpenMobileFilters: () => void;
+  filtersActive: boolean;
+  onReset: () => void;
+  query: string;
+  onQueryChange: (value: string) => void;
+}) {
+  return (
+    <div className='flex items-center gap-3'>
+      <Button
+        appearance='outline'
+        intent='secondary'
+        shape='pill'
+        size='small'
+        onClick={onToggleFilters}
+        className='hidden shrink-0 lg:inline-flex'
+      >
+        {filtersOpen ? (
+          <MoveLeft className='size-4' strokeWidth={1.75} aria-hidden />
+        ) : (
+          <Funnel className='size-4' strokeWidth={1.75} aria-hidden />
+        )}
+        {filtersOpen ? 'Hide Filters' : 'Filters'}
+      </Button>
+
+      <AnimatePresence initial={false}>
+        {filtersActive ? (
+          <motion.div
+            key='reset-desktop'
+            initial={{ opacity: 0, scale: 0.85 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.85 }}
+            transition={transitions.fast}
+            className='hidden shrink-0 lg:block'
+          >
+            <Button
+              appearance='outline'
+              intent='primary'
+              shape='pill'
+              size='small'
+              onClick={onReset}
+            >
+              <RotateCcw className='size-4' strokeWidth={1.75} aria-hidden />
+              Reset
+            </Button>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+
+      <div className='flex flex-1 items-center gap-2 rounded-full border border-[#1f2a28] px-4 py-2.5'>
+        <Search
+          className='size-4 shrink-0 text-muted-foreground'
+          strokeWidth={1.75}
+          aria-hidden
+        />
+        <input
+          value={query}
+          onChange={event => onQueryChange(event.target.value)}
+          placeholder='Search opportunities, skills, or organizations'
+          className='w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground'
+        />
+      </div>
+
+      <Button
+        appearance='outline'
+        intent='secondary'
+        shape='pill'
+        size='small'
+        iconOnly
+        onClick={onOpenMobileFilters}
+        aria-label='Filters'
+        className='shrink-0 lg:hidden'
+      >
+        <ListFilter className='size-5' strokeWidth={1.75} aria-hidden />
+      </Button>
+
+      <AnimatePresence initial={false}>
+        {filtersActive ? (
+          <motion.div
+            key='reset-mobile'
+            initial={{ opacity: 0, scale: 0.85 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.85 }}
+            transition={transitions.fast}
+            className='shrink-0 lg:hidden'
+          >
+            <Button
+              appearance='outline'
+              intent='secondary'
+              shape='pill'
+              size='small'
+              iconOnly
+              onClick={onReset}
+              aria-label='Reset filters'
+            >
+              <RotateCcw className='size-5' strokeWidth={1.75} aria-hidden />
+            </Button>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+
+      <Button
+        appearance='outline'
+        intent='secondary'
+        shape='pill'
+        size='small'
+        className='hidden shrink-0 lg:inline-flex'
+      >
+        <ArrowDownUp className='size-4' strokeWidth={1.75} aria-hidden />
+        Newest
+      </Button>
+    </div>
+  );
+}

--- a/components/discover/filter-rail.tsx
+++ b/components/discover/filter-rail.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { countries } from 'countries-list';
+import { ChevronDown, Layers, MapPin, Search } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import {
+  type ComponentType,
+  type ReactNode,
+  type SVGProps,
+  useState,
+} from 'react';
+
+import { Activity01Icon, Coins02Icon, HashtagIcon } from '@/components/icons';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { transitions } from '@/lib/motion';
+import { cn } from '@/lib/utils';
+
+const STATUS = ['Open', 'Applications', 'Review', 'Completed'];
+const MODE = [
+  'All',
+  'Single claim',
+  'Application',
+  'Competition',
+  'Multiple winners',
+];
+const CATEGORY = [
+  'All',
+  'Design',
+  'Development',
+  'Content',
+  'Growth',
+  'Community',
+  'Other',
+];
+const COUNTRY = Object.values(countries)
+  .map(country => country.name)
+  .sort((a, b) => a.localeCompare(b));
+
+export type CheckboxGroup = 'status' | 'mode' | 'category' | 'country';
+
+export interface FilterValue {
+  status: string[];
+  mode: string[];
+  category: string[];
+  country: string[];
+  currency: string;
+  min: string;
+  max: string;
+}
+
+export const EMPTY_FILTERS: FilterValue = {
+  status: [],
+  mode: [],
+  category: [],
+  country: [],
+  currency: 'USDC',
+  min: '',
+  max: '',
+};
+
+/** True once the visitor has narrowed the results with any control. */
+export function hasActiveFilters(value: FilterValue): boolean {
+  return (
+    value.status.length > 0 ||
+    value.mode.length > 0 ||
+    value.category.length > 0 ||
+    value.country.length > 0 ||
+    value.min.trim() !== '' ||
+    value.max.trim() !== ''
+  );
+}
+
+/** Accepts both lucide icons and our generated SVG icon components. */
+type FilterSectionIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+function FilterSection({
+  icon: Icon,
+  title,
+  defaultOpen = true,
+  children,
+}: {
+  icon: FilterSectionIcon;
+  title: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className='py-4 first:pt-0 last:border-b-0'>
+      <button
+        type='button'
+        onClick={() => setOpen(value => !value)}
+        aria-expanded={open}
+        className='flex w-full items-center gap-2 text-sm font-medium text-foreground'
+      >
+        <Icon
+          className='size-4 text-muted-foreground'
+          strokeWidth={1.75}
+          aria-hidden
+        />
+        <span className='flex-1 text-left'>{title}</span>
+        <ChevronDown
+          className={cn(
+            'size-4 text-muted-foreground transition-transform',
+            open && 'rotate-180'
+          )}
+          aria-hidden
+        />
+      </button>
+      <AnimatePresence initial={false}>
+        {open ? (
+          <motion.div
+            key='content'
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={transitions.base}
+            className='overflow-hidden'
+          >
+            <div className='mt-3 flex flex-col gap-3'>{children}</div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function CheckRow({
+  id,
+  label,
+  checked,
+  onToggle,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <label htmlFor={id} className='flex cursor-pointer items-center gap-2'>
+      <Checkbox id={id} checked={checked} onCheckedChange={() => onToggle()} />
+      <span className='text-sm text-muted-foreground'>{label}</span>
+    </label>
+  );
+}
+
+/**
+ * Discovery filter controls, used in the desktop sidebar and the mobile sheet.
+ * Controlled: the parent owns `value` so it can show a Reset affordance and run
+ * the query. `idPrefix` keeps the two instances from sharing input ids.
+ */
+export function FilterRail({
+  value,
+  onChange,
+  idPrefix = 'rail',
+  className,
+}: {
+  value: FilterValue;
+  onChange: (value: FilterValue) => void;
+  idPrefix?: string;
+  className?: string;
+}) {
+  const [country, setCountry] = useState('');
+  const countries = COUNTRY.filter(name =>
+    name.toLowerCase().includes(country.trim().toLowerCase())
+  );
+
+  const toggle = (group: CheckboxGroup, item: string) => {
+    const current = value[group];
+    const next = current.includes(item)
+      ? current.filter(entry => entry !== item)
+      : [...current, item];
+    onChange({ ...value, [group]: next });
+  };
+
+  const renderRows = (group: CheckboxGroup, items: string[]) =>
+    items.map(item => (
+      <CheckRow
+        key={item}
+        id={`${idPrefix}-${group}-${item}`}
+        label={item}
+        checked={value[group].includes(item)}
+        onToggle={() => toggle(group, item)}
+      />
+    ));
+
+  return (
+    <div className={cn('flex flex-col', className)}>
+      <FilterSection icon={Activity01Icon} title='Status'>
+        {renderRows('status', STATUS)}
+      </FilterSection>
+
+      <FilterSection icon={Layers} title='Mode'>
+        {renderRows('mode', MODE)}
+      </FilterSection>
+
+      <FilterSection icon={Coins02Icon} title='Rewards'>
+        <Select
+          value={value.currency}
+          onValueChange={currency => onChange({ ...value, currency })}
+        >
+          <SelectTrigger
+            aria-label='Reward currency'
+            className='w-full border-[#1f2a28] text-foreground'
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='USDC'>USDC</SelectItem>
+            <SelectItem value='XLM'>XLM</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className='flex items-center gap-2'>
+          <Input
+            type='number'
+            inputSize='small'
+            placeholder='0'
+            aria-label='Minimum reward'
+            value={value.min}
+            onChange={event => onChange({ ...value, min: event.target.value })}
+            className='border-[#1f2a28]'
+          />
+          <span className='text-muted-foreground'>-</span>
+          <Input
+            type='number'
+            inputSize='small'
+            placeholder='0'
+            aria-label='Maximum reward'
+            value={value.max}
+            onChange={event => onChange({ ...value, max: event.target.value })}
+            className='border-[#1f2a28]'
+          />
+        </div>
+      </FilterSection>
+
+      <FilterSection icon={HashtagIcon} title='Category' defaultOpen={false}>
+        {renderRows('category', CATEGORY)}
+      </FilterSection>
+
+      <FilterSection icon={MapPin} title='Country' defaultOpen={false}>
+        <div className='flex items-center gap-2 rounded-md border border-[#1f2a28] px-3 py-2'>
+          <Search
+            className='size-4 shrink-0 text-muted-foreground'
+            strokeWidth={1.75}
+            aria-hidden
+          />
+          <input
+            value={country}
+            onChange={event => setCountry(event.target.value)}
+            placeholder='Search here'
+            className='w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground'
+          />
+        </div>
+        {renderRows('country', countries)}
+      </FilterSection>
+    </div>
+  );
+}

--- a/components/discover/filter-sheet.tsx
+++ b/components/discover/filter-sheet.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+
+import { Button } from '@/components/ui/button';
+
+import { FilterRail, type FilterValue } from './filter-rail';
+
+/**
+ * Full-screen filter sheet for mobile. Opened from the toolbar's filter button;
+ * fills the viewport, scrolls the rail, and keeps Reset/Done pinned. Triggered
+ * only below `lg`, where the inline rail is hidden.
+ */
+export function FilterSheet({
+  open,
+  onOpenChange,
+  value,
+  onChange,
+  onReset,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: FilterValue;
+  onChange: (value: FilterValue) => void;
+  onReset: () => void;
+}) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className='fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0' />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          className='fixed inset-0 z-50 flex h-dvh w-screen flex-col bg-ink text-white outline-none data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=open]:animate-in data-[state=open]:slide-in-from-bottom'
+        >
+          <div className='flex items-center justify-between border-b border-[#1f2a28] px-5 py-4'>
+            <DialogPrimitive.Title className='text-lg font-semibold text-foreground'>
+              Filters
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Close asChild>
+              <Button
+                appearance='text'
+                intent='secondary'
+                size='small'
+                iconOnly
+                aria-label='Close filters'
+                className='rounded-full'
+              >
+                <XIcon className='size-5' />
+              </Button>
+            </DialogPrimitive.Close>
+          </div>
+
+          <div className='flex-1 overflow-y-auto px-5'>
+            <FilterRail idPrefix='sheet' value={value} onChange={onChange} />
+          </div>
+
+          <div className='flex items-center gap-3 border-t border-[#1f2a28] px-5 py-4'>
+            <Button
+              appearance='outline'
+              intent='secondary'
+              shape='pill'
+              className='flex-1'
+              onClick={onReset}
+            >
+              Reset
+            </Button>
+            <Button
+              intent='primary'
+              shape='pill'
+              className='flex-1'
+              onClick={() => onOpenChange(false)}
+            >
+              Done
+            </Button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -1,0 +1,19 @@
+import type { Transition } from 'motion/react';
+
+/**
+ * Shared motion tokens. Keep transitions subtle and GPU-friendly
+ * (opacity/transform only) and tune timing here so it stays consistent.
+ */
+
+export const EASE_OUT: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+export const DURATION = { fast: 0.18, base: 0.28 } as const;
+
+export const STAGGER = 0.04;
+/** Cap the per-index stagger so long lists do not feel slow. */
+export const STAGGER_CAP = 8;
+
+export const transitions = {
+  fast: { duration: DURATION.fast, ease: EASE_OUT },
+  base: { duration: DURATION.base, ease: EASE_OUT },
+} satisfies Record<string, Transition>;


### PR DESCRIPTION
Vendors the presentational discover components from boundless-platform so the upcoming `/projects` directory page can reuse them (like we did for the design system). Prep for the projects-page issues.

### Ported into `components/discover/`
- `category-tabs.tsx` — the horizontal category switcher
- `filter-rail.tsx` — desktop filter rail (defines `FilterValue`, `EMPTY_FILTERS`, `hasActiveFilters`)
- `filter-sheet.tsx` — mobile filter sheet (wraps the rail)
- `discover-toolbar.tsx` — sort / result-count / filter toggle
- `discover-header.tsx` — results header
- plus `lib/motion.ts` (shared motion tokens they use)

### Notes
- All are **controlled/presentational** (the parent owns filter state), so they port cleanly. Build + lint pass.
- `FilterRail`'s `FilterValue` is currently the **bounties** shape (status/mode/category/country/min/max). The projects page will adapt it to the real project facets (`category`/`tags`/`publicStatus`/`originType` from `GET /projects/filters`).
- The API-coupled `discover-view` orchestrator and `pillar-tabs` are intentionally **not** ported (the projects page has no pillar tabs, and builds its own view).

Reference: the live boundless discover/bounties page shows these in action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category tabs with active-state selection.
  * Added a discovery header with result counts and navigation actions.
  * Added search, filter, reset, and sorting controls for discovery results.
  * Added desktop filter panels and a mobile filter sheet with status, category, country, reward, and range options.
  * Added animated filter control transitions for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->