### PR TITLE
docs: use /users/top-builders for the top builders row

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -39,15 +39,31 @@ truth.
 
 | Endpoint | Purpose | Status |
 | --- | --- | --- |
-| `GET /leaderboard` | Top builders row (`limit`, `page`, `timeframe`, `tier`) | Public |
+| `GET /users/top-builders` | Top builders row. Card-ready. Accepts `limit`. | Public |
 | `GET /projects/featured` | Featured projects row | Public |
 | `GET /discover/landing` | Ecosystem feed / counts | Public |
 | `GET /discover/recent-winners` | Recent winners highlight | Public |
 | `GET /users/directory?limit=N` | Fallback source for a builders strip | Public |
+| `GET /leaderboard` | Ranking + reputation (tier, score, stats). Not card-ready. | Public |
 
-> There is no "featured builders" flag. The landing "top builders" row uses
-> `GET /leaderboard`. A stats strip can derive counts from the `pagination.total`
-> of `GET /users/directory`, `GET /projects`, and `GET /organizations`.
+> **Top builders:** use `GET /users/top-builders`. It returns a flat array of
+> card-ready builders in the standard `{ success, message, data, meta }`
+> envelope, with everything `BuilderCardView` needs:
+>
+> ```json
+> { "id", "name", "username", "image", "role", "location",
+>   "country", "skills": [], "followers": 0, "projects": 0 }
+> ```
+>
+> Map: `name` -> displayName, `image` -> avatarSrc, `location` -> location,
+> `skills`/`followers`/`projects` straight across. Do **not** map `role` (it is
+> the account role, e.g. `"user"`, not a professional title). `GET /leaderboard`
+> is kept for ranking/reputation use only; it does **not** carry profile fields
+> (role, location, followers, projects), which is why the landing top-builders
+> row moved to `GET /users/top-builders`.
+>
+> A stats strip can derive counts from the `pagination.total` of
+> `GET /users/directory`, `GET /projects`, and `GET /organizations`.
 
 ---
 


### PR DESCRIPTION
The backend added `GET /api/users/top-builders`, a card-ready endpoint for the landing top-builders row. This updates `ENDPOINTS.md` to use it as the source and demotes `GET /leaderboard` to ranking/reputation only.

Verified against staging: returns a flat array of `{ id, name, username, image, role, location, country, skills[], followers, projects }` with CORS for localhost, and accepts `?limit=`. Every `BuilderCardView` field is present (unlike the leaderboard). Note: `role` is the account role (`"user"`), so it should not be mapped to the card.

Pairs with the follow-up issue to switch the `TopBuilders` section off the leaderboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the public `GET /users/top-builders` endpoint.
  * Clarified the response format and field mappings for top-builder cards.
  * Updated landing-page guidance to use the dedicated top-builders endpoint instead of the leaderboard.
  * Updated stats-strip guidance to reference directory, project, and organization totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->