### PR TITLE
feat(landing): switch Top builders to /users/top-builders

### DIFF
--- a/components/landing/to-builder-card.ts
+++ b/components/landing/to-builder-card.ts
@@ -2,51 +2,31 @@ import type { BuilderCardView } from '@/components/cards/types';
 
 const MAX_SKILLS = 4;
 
-export interface LeaderboardStats {
-  totalCompleted: number;
-  totalWins: number;
-  totalEarnings: number;
-  earningsCurrency: string;
-  totalEarningsUsdc: number;
-  completionRate: number;
-  averageCompletionTime: number;
-  currentStreak: number;
-  longestStreak: number;
-}
-
-export interface LeaderboardContributor {
+/** One row of `GET /users/top-builders`. */
+export interface TopBuilder {
   id: string;
-  userId: string;
+  name: string;
   username: string;
-  displayName: string;
-  avatarUrl: string | null;
-  totalScore: number;
-  tier: string;
-  stats: LeaderboardStats;
-  topTags: string[];
-  lastActiveAt: string;
+  image: string | null;
+  /** Account role ("user"), not a professional title. Not mapped to the card. */
+  role: string;
+  location: string | null;
+  country: string | null;
+  skills: string[];
+  followers: number;
+  projects: number;
 }
 
-export interface LeaderboardEntry {
-  rank: number;
-  contributor: LeaderboardContributor;
-}
-
-export interface LeaderboardData {
-  entries: LeaderboardEntry[];
-  totalCount: number;
-  lastUpdatedAt: string;
-}
-
-export function toBuilderCard({
-  contributor,
-}: LeaderboardEntry): BuilderCardView {
+export function toBuilderCard(builder: TopBuilder): BuilderCardView {
   return {
-    id: contributor.id,
-    displayName: contributor.displayName,
-    username: contributor.username,
-    avatarSrc: contributor.avatarUrl ?? undefined,
-    skills: contributor.topTags.slice(0, MAX_SKILLS),
-    detailUrl: `/builders/${contributor.username}`,
+    id: builder.id,
+    displayName: builder.name,
+    username: builder.username,
+    avatarSrc: builder.image ?? undefined,
+    location: builder.location ?? builder.country ?? undefined,
+    skills: builder.skills.slice(0, MAX_SKILLS),
+    followers: builder.followers,
+    projects: builder.projects,
+    detailUrl: `/builders/${builder.username}`,
   };
 }

--- a/components/landing/top-builders.tsx
+++ b/components/landing/top-builders.tsx
@@ -10,20 +10,15 @@ import { Section, SectionHeading } from '@/components/marketing/section';
 import { Button } from '@/components/ui/button';
 import { apiFetch } from '@/lib/api/client';
 
-import {
-  type LeaderboardData,
-  toBuilderCard,
-} from './to-builder-card';
+import { type TopBuilder, toBuilderCard } from './to-builder-card';
 
 const TOP_BUILDERS_LIMIT = 8;
 
 function useTopBuilders() {
   return useQuery({
-    queryKey: ['leaderboard', 'top-builders', TOP_BUILDERS_LIMIT],
+    queryKey: ['users', 'top-builders', TOP_BUILDERS_LIMIT],
     queryFn: () =>
-      apiFetch<LeaderboardData>(
-        `/leaderboard?limit=${TOP_BUILDERS_LIMIT}`
-      ),
+      apiFetch<TopBuilder[]>(`/users/top-builders?limit=${TOP_BUILDERS_LIMIT}`),
   });
 }
 
@@ -47,7 +42,7 @@ function EmptyState() {
 
 export function TopBuilders() {
   const { data, isError, isPending } = useTopBuilders();
-  const builders = data?.entries.map(toBuilderCard) ?? [];
+  const builders = data?.map(toBuilderCard) ?? [];
 
   return (
     <Section reveal innerClassName='flex flex-col gap-8'>

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,14 @@ const nextConfig: NextConfig = {
         pathname: '/danuy5rqb/image/upload/**',
         search: '',
       },
+      // Avatars for builders who signed up with Google.
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+        port: '',
+        pathname: '/**',
+        search: '',
+      },
     ],
   },
 };


### PR DESCRIPTION
Closes #353.

## What changed

- **`components/landing/top-builders.tsx`** — the query now calls `GET /users/top-builders?limit=8` and maps the flat array directly (`data?.map(toBuilderCard)`). Query key moved from `['leaderboard', ...]` to `['users', 'top-builders', ...]`.
- **`components/landing/to-builder-card.ts`** — `LeaderboardData` / `LeaderboardEntry` / `LeaderboardContributor` / `LeaderboardStats` replaced by a single flat `TopBuilder` interface, with the mapper updated to match.

`role` is deliberately not mapped: the endpoint returns the account role (`"user"`), not a professional title. That is noted on the field in `TopBuilder` so it does not get "fixed" later.

The section now fills `location`, `followers`, and `projects`, which the leaderboard shape could not supply.

## One change beyond the stated scope

Switching endpoints surfaces a runtime error that takes down the whole landing page:

```
Invalid src prop (https://lh3.googleusercontent.com/a/ACg8ocL-...) on `next/image`,
hostname "lh3.googleusercontent.com" is not configured under images in your `next.config.js`
```

`BuilderCard` renders avatars through `Avatar`, which uses `next/image`, and `next.config.ts` only allowlists `res.cloudinary.com`. Builders who signed up with Google have avatars on `lh3.googleusercontent.com`. The old leaderboard row never returned one, so the switch is what exposes it. Across the current staging data those are the only two avatar hosts in use.

So this PR also adds `lh3.googleusercontent.com` to `images.remotePatterns`. Without it the section cannot render at all, so it did not seem sensible to split out. Happy to move it to its own PR if you would rather keep this one to the data source and mapper.

## Verification

Run against staging, checking all three states:

- **Data** — the three staging builders render with name, `@username`, location, skill pills, and follower / project counts. Cloudinary avatar, Google avatar, and the initials fallback for a builder with no image all display correctly. No `role` line on any card.
- **Empty** — a `[]` response renders "No builders to show yet."
- **Error** — a 500 renders "Top builders could not be loaded right now."

`npm run lint` and `npm run build` pass.

Screenshot to follow in a comment below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the landing page to display top builders from the latest builder directory.
  * Builder cards now show follower and project counts alongside profile details.
  * Added support for displaying Google-hosted profile avatars.

* **Bug Fixes**
  * Improved builder data loading to use the dedicated top-builders feed while preserving existing loading, error, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->