### PR TITLE
feat(projects-page): compose /projects route + header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import {
   FeaturedProjects,
   StatsStrip,
@@ -33,8 +35,8 @@ export default function Home() {
           </p>
           <div className='mt-10 flex flex-wrap items-center justify-center gap-4'>
             <Button size='large'>Explore builders</Button>
-            <Button intent='secondary' appearance='outline' size='large'>
-              View projects
+            <Button intent='secondary' appearance='outline' size='large' asChild>
+              <Link href='/projects'>View projects</Link>
             </Button>
           </div>
         </Section>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+
+import { ProjectsView } from '@/components/discover/projects-view';
+import { SiteFooter } from '@/components/layout/site-footer';
+import { SiteHeader } from '@/components/layout/site-header';
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description:
+    'Explore the products being built across the Boundless ecosystem.',
+};
+
+export default function ProjectsPage() {
+  return (
+    <>
+      <SiteHeader />
+      <ProjectsView />
+      <SiteFooter />
+    </>
+  );
+}

--- a/components/discover/discover-header.tsx
+++ b/components/discover/discover-header.tsx
@@ -7,10 +7,13 @@ export function DiscoverHeader({
   heading,
   subtext,
   count,
+  showActions = true,
 }: {
   heading: string;
   subtext: string;
   count?: number;
+  /** Bookmarks / Leaderboard buttons. Off for views that have neither. */
+  showActions?: boolean;
 }) {
   return (
     <div className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
@@ -26,28 +29,30 @@ export function DiscoverHeader({
         </h1>
         <p className='text-sm text-muted-foreground'>{subtext}</p>
       </div>
-      <div className='hidden items-center gap-3 sm:flex'>
-        <Button
-          appearance='outline'
-          intent='secondary'
-          shape='pill'
-          size='small'
-          aria-pressed='true'
-        >
-          <Bookmark className='size-4' strokeWidth={1.75} aria-hidden />
-          Bookmarks
-        </Button>
-        <Button
-          appearance='solid'
-          intent='white'
-          shape='pill'
-          size='small'
-          aria-pressed='true'
-        >
-          <Users className='size-4' strokeWidth={1.75} aria-hidden />
-          Leaderboard
-        </Button>
-      </div>
+      {showActions ? (
+        <div className='hidden items-center gap-3 sm:flex'>
+          <Button
+            appearance='outline'
+            intent='secondary'
+            shape='pill'
+            size='small'
+            aria-pressed='true'
+          >
+            <Bookmark className='size-4' strokeWidth={1.75} aria-hidden />
+            Bookmarks
+          </Button>
+          <Button
+            appearance='solid'
+            intent='white'
+            shape='pill'
+            size='small'
+            aria-pressed='true'
+          >
+            <Users className='size-4' strokeWidth={1.75} aria-hidden />
+            Leaderboard
+          </Button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/discover/discover-toolbar.tsx
+++ b/components/discover/discover-toolbar.tsx
@@ -21,6 +21,7 @@ export function DiscoverToolbar({
   onReset,
   query,
   onQueryChange,
+  placeholder = 'Search opportunities, skills, or organizations',
 }: {
   filtersOpen: boolean;
   onToggleFilters: () => void;
@@ -29,6 +30,7 @@ export function DiscoverToolbar({
   onReset: () => void;
   query: string;
   onQueryChange: (value: string) => void;
+  placeholder?: string;
 }) {
   return (
     <div className='flex items-center gap-3'>
@@ -81,7 +83,7 @@ export function DiscoverToolbar({
         <input
           value={query}
           onChange={event => onQueryChange(event.target.value)}
-          placeholder='Search opportunities, skills, or organizations'
+          placeholder={placeholder}
           className='w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground'
         />
       </div>

--- a/components/discover/projects-grid.tsx
+++ b/components/discover/projects-grid.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { OpportunityCard } from '@/components/cards/opportunity-card';
+import { OpportunityCardSkeleton } from '@/components/cards/opportunity-card-skeleton';
+import { Pagination } from '@/components/ui/pagination';
+import type { Paginated } from '@/lib/api/types';
+
+import { toProjectCard } from './to-project-card';
+import type { ProjectListItemDto } from './use-projects';
+
+const GRID_CLASS = 'grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3';
+
+export function ProjectsGrid({
+  data,
+  isPending,
+  isError,
+  isNarrowed,
+  page,
+  pageSize,
+  onPageChange,
+}: {
+  data?: Paginated<ProjectListItemDto>;
+  isPending: boolean;
+  isError: boolean;
+  /** A search or filter is applied, so an empty result is a miss, not an empty directory. */
+  isNarrowed: boolean;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}) {
+  if (isPending) {
+    return (
+      <div className={GRID_CLASS}>
+        {Array.from({ length: pageSize }, (_, index) => (
+          <OpportunityCardSkeleton key={index} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <p className='py-12 text-center text-body-sm text-muted-foreground'>
+        Projects could not be loaded right now.
+      </p>
+    );
+  }
+
+  if (data.data.length === 0) {
+    return (
+      <p className='py-12 text-center text-body-sm text-muted-foreground'>
+        {isNarrowed
+          ? 'No projects match these filters.'
+          : 'No projects to show yet.'}
+      </p>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-8'>
+      <div className={GRID_CLASS}>
+        {data.data.map((project, index) => (
+          <OpportunityCard
+            key={project.id}
+            // Keep the card's `#n` running across pages instead of restarting.
+            opportunity={toProjectCard(project, (page - 1) * pageSize + index)}
+          />
+        ))}
+      </div>
+
+      <Pagination
+        page={page}
+        pageSize={pageSize}
+        totalItems={data.pagination.total}
+        onPageChange={onPageChange}
+        className='justify-between'
+      />
+    </div>
+  );
+}

--- a/components/discover/projects-view.tsx
+++ b/components/discover/projects-view.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { Section } from '@/components/marketing/section';
+
+import { CategoryTabs } from './category-tabs';
+import { DiscoverHeader } from './discover-header';
+import { DiscoverToolbar } from './discover-toolbar';
+import {
+  EMPTY_FILTERS,
+  FilterRail,
+  hasActiveFilters,
+  type FilterValue,
+} from './filter-rail';
+import { FilterSheet } from './filter-sheet';
+import { ProjectsGrid } from './projects-grid';
+import {
+  useProjectFilters,
+  useProjects,
+  type ProjectsQueryParams,
+} from './use-projects';
+
+const PAGE_SIZE = 12;
+const ALL_CATEGORIES = 'All';
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * The `/projects` directory. Owns the search, category, filter, and page state
+ * and feeds it to `useProjects`, so the controls, the rail, and the grid all
+ * read from one source. The projects equivalent of the boundless `discover-view`,
+ * minus the pillar tabs, since this page is projects only.
+ */
+export function ProjectsView() {
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState<FilterValue>(EMPTY_FILTERS);
+  const [page, setPage] = useState(1);
+  const [railOpen, setRailOpen] = useState(true);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  // Keep typing off the network until the visitor pauses. Narrowing the results
+  // invalidates the page number, so the debounce resets it too.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearch(searchInput);
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const applyFilters = (next: FilterValue) => {
+    setFilters(next);
+    setPage(1);
+  };
+
+  const params = useMemo<ProjectsQueryParams>(
+    () => ({
+      page,
+      limit: PAGE_SIZE,
+      search: search || undefined,
+      // `GET /projects` takes a single value for these three, so a multi-select
+      // in the rail sends its first entry. Only `tags` is repeatable.
+      category: filters.category[0],
+      publicStatus: filters.publicStatus[0],
+      originType: filters.originType[0],
+      tags: filters.tags.length > 0 ? filters.tags : undefined,
+    }),
+    [page, search, filters]
+  );
+
+  const { data, isError, isPending } = useProjects(params);
+  const { data: facets } = useProjectFilters();
+
+  const categories = useMemo(
+    () => [
+      ALL_CATEGORIES,
+      ...(facets?.categories.map(item => item.value) ?? []),
+    ],
+    [facets]
+  );
+
+  const reset = () => applyFilters(EMPTY_FILTERS);
+
+  const selectCategory = (category: string) =>
+    applyFilters({
+      ...filters,
+      category: category === ALL_CATEGORIES ? [] : [category],
+    });
+
+  return (
+    <Section className='py-10 lg:py-12' innerClassName='flex flex-col gap-6'>
+      <DiscoverHeader
+        heading='Projects'
+        subtext='Explore the products being built across the Boundless ecosystem.'
+        count={data?.pagination.total}
+        showActions={false}
+      />
+
+      <CategoryTabs
+        categories={categories}
+        active={filters.category[0] ?? ALL_CATEGORIES}
+        onSelect={selectCategory}
+      />
+
+      <DiscoverToolbar
+        filtersOpen={railOpen}
+        onToggleFilters={() => setRailOpen(open => !open)}
+        onOpenMobileFilters={() => setSheetOpen(true)}
+        filtersActive={hasActiveFilters(filters)}
+        onReset={reset}
+        query={searchInput}
+        onQueryChange={setSearchInput}
+        placeholder='Search projects, categories, or tags'
+      />
+
+      <div className='flex items-start gap-6'>
+        {railOpen ? (
+          <aside className='hidden w-[260px] shrink-0 lg:block'>
+            <FilterRail value={filters} onChange={applyFilters} />
+          </aside>
+        ) : null}
+
+        <div className='min-w-0 flex-1'>
+          <ProjectsGrid
+            data={data}
+            isPending={isPending}
+            isError={isError}
+            isNarrowed={hasActiveFilters(filters) || search.length > 0}
+            page={page}
+            pageSize={PAGE_SIZE}
+            onPageChange={setPage}
+          />
+        </div>
+      </div>
+
+      <FilterSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        value={filters}
+        onChange={applyFilters}
+        onReset={reset}
+      />
+    </Section>
+  );
+}


### PR DESCRIPTION
Closes #351.

Assembles the projects directory: compact page header, category tabs, search + toolbar, filter rail (desktop) / filter sheet (mobile), results grid, pagination. No pillar tabs, no promo banner.

## What changed

**New**
- `app/projects/page.tsx` — thin server route: `SiteHeader` -> `ProjectsView` -> `SiteFooter`, plus page metadata.
- `components/discover/projects-view.tsx` — the client orchestrator. Owns `search`, `FilterValue`, `category`, and `page`, and feeds them to `useProjects` so the controls, the rail, and the grid all read from one source. Search is debounced (300ms) and any narrowing resets the page number.
- `components/discover/projects-grid.tsx` — results grid with loading / error / empty states and pagination.

**Touched (small, additive, both default to today's behavior)**
- `discover-header.tsx` — added `showActions`, passed `false` here. The Bookmarks and Leaderboard buttons have no destination in this read-only app, so they would render as dead controls.
- `discover-toolbar.tsx` — added an optional `placeholder`, since the default reads "Search opportunities, skills, or organizations" on a projects page.

Category tabs and the rail's Category group both write to `filters.category`, so they stay in sync instead of fighting over the same query param. Card numbering (`#n`) runs across pages rather than restarting at each page.

## Please read: two things worth a second opinion

**1. This depends on #350, which has not landed.** The issue lists the results grid as a dependency, but #350 has no PR yet, and `/projects` cannot render without a grid. I wrote a minimal `projects-grid.tsx` so the page works end to end. It is deliberately small and presentational (props in, no data fetching), so #350 can replace the file wholesale. Happy to drop it and rebase onto #350 if its author would rather own it. #349 (PR #357) adds `project-search.tsx`, which I did not import since it is not on `main`; the search input already in `DiscoverToolbar` is doing the job, and swapping it in later is a one-line change.

**2. Multi-select filters are lossy against the current API.** `GET /projects` accepts a single value for `category`, `publicStatus`, and `originType` (only `tags` is repeatable), but the rail from #348 renders all four as multi-select checkboxes. Ticking a second status currently has no effect: the view sends `filters.publicStatus[0]`. I did not paper over it by sending an unverified CSV. Either the rail should be single-select for those three, or the backend should accept repeated values. Flagging rather than deciding it here.

## Verification

Driven in a real browser over the DevTools protocol against a stubbed 30-project dataset, since staging currently returns **zero** public projects (`GET /api/projects` -> `total: 0`).

| Action | Result |
| --- | --- |
| initial | `Projects (30)`, 12 cards, "Showing 1 to 12 of 30 items" |
| category tab `Gaming` | `Projects (7)`, all Gaming |
| search `Payments Project 1` | `Projects (2)` |
| filter `Beta` | `Projects (8)` |
| `Reset` | back to 30, page 1 |
| page `3` | "Showing 25 to 30 of 30 items", numbering continues at #25 |

Requests on the wire confirm the wiring and the page reset:

```
/api/projects?page=1&limit=12
/api/projects?page=1&limit=12&category=Gaming
/api/projects?page=1&limit=12&search=Payments+Project+1
/api/projects?page=1&limit=12&publicStatus=BETA
/api/projects?page=3&limit=12
```

Mobile checked at 390x844 with device emulation: single column, scrollable tabs, filter sheet opens with Reset / Done pinned. `document.scrollWidth === window.innerWidth`, so no horizontal overflow.

Against live staging the page renders correctly with the empty state. Note `GET /projects/filters` still reports `DeFi & Finance (1)` while the list returns 0 items, so the facet counts and the list disagree on staging. That is a backend inconsistency, not a page bug, but it is visible.

`npm run lint` and `npm run build` pass.

Screenshots to follow in a comment below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Projects page with searchable, filterable project listings.
  - Added category filters, pagination, responsive filter controls, and mobile-friendly layouts.
  - Added loading placeholders, empty states, and error messaging.
  - Added configurable search guidance and optional header actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->