### PR TITLE
feat(landing): count the ecosystem stats up from zero

### DIFF
--- a/components/landing/stats-strip.tsx
+++ b/components/landing/stats-strip.tsx
@@ -3,6 +3,7 @@
 import { useQueries } from '@tanstack/react-query';
 
 import { Section } from '@/components/marketing/section';
+import { CountUp } from '@/components/ui/count-up';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatsBar, type StatItem } from '@/components/ui/stats-bar';
 import { apiFetch } from '@/lib/api/client';
@@ -25,8 +26,6 @@ const STATS = [
     queryKey: ['ecosystem-stats', 'teams'],
   },
 ] as const;
-
-const numberFormatter = new Intl.NumberFormat('en-US');
 
 function NumberSkeleton({ mobile = false }: { mobile?: boolean }) {
   return (
@@ -74,9 +73,7 @@ export function StatsStrip() {
       return [];
     }
 
-    const value = numberFormatter.format(query.data);
-
-    return [{ label: stat.label, value }];
+    return [{ label: stat.label, value: <CountUp value={query.data} /> }];
   });
 
   if (items.length === 0) return null;

--- a/components/ui/count-up.tsx
+++ b/components/ui/count-up.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {
+  animate,
+  motion,
+  useInView,
+  useMotionValue,
+  useReducedMotion,
+  useTransform,
+} from 'motion/react';
+import { useEffect, useRef } from 'react';
+
+const formatter = new Intl.NumberFormat('en-US');
+
+/**
+ * Counts up from 0 to `value` once it scrolls into view. Formats with thousands
+ * separators. Honors reduced motion by showing the final value at once. Drives
+ * the text with a motion value, so the tick does not re-render React.
+ */
+export function CountUp({
+  value,
+  duration = 1.6,
+}: {
+  value: number;
+  duration?: number;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.5 });
+  const reduceMotion = useReducedMotion();
+  const count = useMotionValue(0);
+  const text = useTransform(count, latest =>
+    formatter.format(Math.round(latest))
+  );
+
+  useEffect(() => {
+    if (!inView) return;
+
+    if (reduceMotion || value === 0) {
+      count.set(value);
+      return;
+    }
+
+    const controls = animate(count, value, {
+      duration,
+      ease: [0.16, 1, 0.3, 1],
+    });
+
+    return () => controls.stop();
+  }, [inView, value, duration, reduceMotion, count]);
+
+  return <motion.span ref={ref}>{text}</motion.span>;
+}


### PR DESCRIPTION
The landing stats strip now animates its numbers up from 0 to their values.

- New `components/ui/count-up.tsx`: a `CountUp` component that counts from 0 to `value` when it scrolls into view, formatted with thousands separators.
- Driven by a **motion value** (via `useMotionValue` / `useTransform` / `animate`), so the per-frame tick does not re-render React.
- **Honors reduced motion** (shows the final value at once) and only runs once, when in view.
- Wired into the Builders / Projects / Teams counts in `stats-strip.tsx`.

Verified: `npm run lint` and `npm run build` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated count-up effects for numeric statistics as they enter view.
  * Numbers display with rounded values and thousands separators.
  * Animations respect reduced-motion preferences for a more accessible experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->