### PR TITLE
chore(discover): tidy ported bounty leftovers on the projects page

### DIFF
--- a/components/discover/discover-header.tsx
+++ b/components/discover/discover-header.tsx
@@ -1,58 +1,22 @@
-import { Bookmark, Users } from 'lucide-react';
-
-import { Button } from '@/components/ui/button';
-
-/** Page header for a discovery view: title with result count, subtext, actions. */
+/** Page header for a discovery view: title with result count and subtext. */
 export function DiscoverHeader({
   heading,
   subtext,
   count,
-  showActions = true,
 }: {
   heading: string;
   subtext: string;
   count?: number;
-  /** Bookmarks / Leaderboard buttons. Off for views that have neither. */
-  showActions?: boolean;
 }) {
   return (
-    <div className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
-      <div className='flex flex-col gap-1'>
-        <h1 className='text-2xl font-semibold tracking-tight text-foreground sm:text-[32px]'>
-          {heading}
-          {typeof count === 'number' ? (
-            <span className='font-normal text-muted-foreground'>
-              {' '}
-              ({count})
-            </span>
-          ) : null}
-        </h1>
-        <p className='text-sm text-muted-foreground'>{subtext}</p>
-      </div>
-      {showActions ? (
-        <div className='hidden items-center gap-3 sm:flex'>
-          <Button
-            appearance='outline'
-            intent='secondary'
-            shape='pill'
-            size='small'
-            aria-pressed='true'
-          >
-            <Bookmark className='size-4' strokeWidth={1.75} aria-hidden />
-            Bookmarks
-          </Button>
-          <Button
-            appearance='solid'
-            intent='white'
-            shape='pill'
-            size='small'
-            aria-pressed='true'
-          >
-            <Users className='size-4' strokeWidth={1.75} aria-hidden />
-            Leaderboard
-          </Button>
-        </div>
-      ) : null}
+    <div className='flex flex-col gap-1'>
+      <h1 className='text-2xl font-semibold tracking-tight text-foreground sm:text-[32px]'>
+        {heading}
+        {typeof count === 'number' ? (
+          <span className='font-normal text-muted-foreground'> ({count})</span>
+        ) : null}
+      </h1>
+      <p className='text-sm text-muted-foreground'>{subtext}</p>
     </div>
   );
 }

--- a/components/discover/discover-toolbar.tsx
+++ b/components/discover/discover-toolbar.tsx
@@ -21,7 +21,7 @@ export function DiscoverToolbar({
   onReset,
   query,
   onQueryChange,
-  placeholder = 'Search opportunities, skills, or organizations',
+  placeholder = 'Search',
 }: {
   filtersOpen: boolean;
   onToggleFilters: () => void;

--- a/components/discover/projects-view.tsx
+++ b/components/discover/projects-view.tsx
@@ -94,7 +94,6 @@ export function ProjectsView() {
         heading='Projects'
         subtext='Explore the products being built across the Boundless ecosystem.'
         count={data?.pagination.total}
-        showActions={false}
       />
 
       <CategoryTabs


### PR DESCRIPTION
Cleanup pass now that the `/projects` directory has fully landed. Removes the bounty-specific leftovers in the ported discover components that do not apply to this read-only builders app.

- **`discover-header`**: drop the Bookmarks / Leaderboard actions and the `showActions` prop. They have no destination here, so that branch only ever rendered off. Header is now just title + count + subtext.
- **`discover-toolbar`**: default search placeholder goes from `"Search opportunities, skills, or organizations"` to a neutral `"Search"` (the projects page passes its own copy anyway).
- **`projects-view`**: drop the now-removed `showActions` prop.

No behavior change on the projects page (those actions were already off). `npm run lint` and `npm run build` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Simplified the Discover page header by removing Bookmark and Leaderboard action buttons.
  * Updated the search field placeholder to display “Search.”
  * Preserved the header’s title, optional count, and supporting text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->