### PR TITLE
fix(landing): blend hero bottom into the section below

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
     <>
       <SiteHeader />
 
-      <HeroBackground fieldHeight={640}>
+      <HeroBackground fieldHeight={640} fadeBottom>
         <Section className='py-24 text-center lg:py-32'>
           <div className='inline-flex items-center rounded-full border border-white/10 bg-white/5 p-1 text-body-xs text-white/70'>
             <span className='rounded-full bg-white/10 px-3 py-1 font-medium text-white'>

--- a/components/landing/stats-strip.tsx
+++ b/components/landing/stats-strip.tsx
@@ -79,10 +79,7 @@ export function StatsStrip() {
   if (items.length === 0) return null;
 
   return (
-    <Section
-      reveal
-      className='bg-[linear-gradient(180deg,rgba(46,237,170,0.08)_0%,rgba(13,17,17,0)_100%)]'
-    >
+    <Section reveal>
       <StatsBar items={items} />
     </Section>
   );

--- a/components/marketing/hero-background.tsx
+++ b/components/marketing/hero-background.tsx
@@ -43,10 +43,11 @@ export function HeroBackground({
   children?: ReactNode;
   fieldHeight?: number;
   /**
-   * For heroes stretched to the footer: resolve the teal tint back to ink at
-   * the very bottom within this one gradient, so the page meets the next
-   * section with no seam (instead of clipping at the teal peak). Default heroes
-   * keep the tint peaking at the bottom edge.
+   * Peak the teal tint just above the bottom, then resolve it back to ink at
+   * the very bottom within this one gradient, so the hero meets whatever
+   * follows with no seam (instead of clipping at the teal peak). Default heroes
+   * keep the tint peaking at the bottom edge, which only reads clean when the
+   * next section starts on the same teal.
    */
   fadeBottom?: boolean;
 }) {

--- a/components/marketing/hero-section.tsx
+++ b/components/marketing/hero-section.tsx
@@ -22,8 +22,8 @@ interface HeroSectionProps {
   showMedia?: boolean;
   /**
    * Resolve the teal tint back to ink at the very bottom so the hero meets the
-   * next section (or the footer) with no seam. Use when the hero sits directly
-   * above the footer.
+   * next section (or the footer) with no seam. Leave off only when the section
+   * below starts on the same teal tint.
    */
   fadeBottom?: boolean;
   className?: string;


### PR DESCRIPTION
## Problem

The bottom of the landing hero did not blend with the section below it. The hero's background gradient ended at its **peak** teal tint (`rgba(46, 237, 170, 0.08)` at the `100%` stop) exactly at the hero's bottom edge, while the next section sits on flat `#0D1111`. The two met as a hard horizontal step.

This only looked correct when `StatsStrip` rendered, because that component carried its own teal-to-ink gradient to continue the glow. `StatsStrip` returns `null` whenever its three stat queries fail or come back empty, so a clean seam depended on an API call succeeding.

## Fix

- `app/page.tsx` — the hero now passes `fadeBottom`. The tint peaks just above the base and resolves back to ink at the edge, inside the hero's own gradient, so it blends into whatever follows.
- `components/landing/stats-strip.tsx` — dropped the gradient class. With the hero self-contained, a strip starting at full teal would reintroduce the same step in reverse.
- Updated the `fadeBottom` doc comments in `hero-background.tsx` and `hero-section.tsx`, which said the prop was only for heroes sitting directly above the footer.

## Verification

`npx tsc --noEmit`, `npm run lint`, and `npm run build` all pass.

Checked locally in a browser. The data sections were empty there because the backend API was not reachable from my machine, so they fell into their error and empty states. The seam sits at the hero's bottom edge and renders independently of that data.

**Before** — hard line at the hero base, lighter teal above, flat ink below.

**After** — continuous fade, no visible edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the home page hero background with a smoother fade into the content below.
  * Refined the statistics section’s background styling for a cleaner transition between sections.
  * Improved visual consistency between hero areas and surrounding page sections.
* **Documentation**
  * Clarified how hero background fades appear and how they transition into adjacent sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->