### PR TITLE
Sync builders directory state to the URL

### DIFF
--- a/app/builders/page.tsx
+++ b/app/builders/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+
+import { BuildersView } from '@/components/builders/builders-view';
+import { SiteFooter } from '@/components/layout/site-footer';
+import { SiteHeader } from '@/components/layout/site-header';
+
+export const metadata: Metadata = {
+  title: 'Builders',
+  description: 'Discover people building across the Boundless ecosystem.',
+};
+
+export default function BuildersPage() {
+  return (
+    <>
+      <SiteHeader />
+      <Suspense fallback={null}>
+        <BuildersView />
+      </Suspense>
+      <SiteFooter />
+    </>
+  );
+}

--- a/components/builders/builders-view.tsx
+++ b/components/builders/builders-view.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { Search } from 'lucide-react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { BuilderCard } from '@/components/cards/builder-card';
+import { BuilderCardSkeleton } from '@/components/cards/builder-card-skeleton';
+import { Pagination } from '@/components/ui/pagination';
+import { Section } from '@/components/marketing/section';
+
+import {
+  type BuilderSort,
+  type BuilderStatus,
+  useBuilderFilters,
+  useBuilders,
+} from './use-builders';
+
+const PAGE_SIZE = 12;
+const SEARCH_DEBOUNCE_MS = 300;
+const DEFAULT_SORT: BuilderSort = 'newest';
+
+interface DirectoryState {
+  search: string;
+  skills: string[];
+  country: string;
+  status: BuilderStatus | '';
+  sort: BuilderSort;
+  page: number;
+}
+
+function isBuilderSort(value: string | null): value is BuilderSort {
+  return (
+    value === 'name_asc' ||
+    value === 'name_desc' ||
+    value === 'newest' ||
+    value === 'oldest'
+  );
+}
+
+function isBuilderStatus(value: string | null): value is BuilderStatus {
+  return (
+    value === 'AVAILABLE' ||
+    value === 'OPEN_TO_WORK' ||
+    value === 'BUSY' ||
+    value === 'UNAVAILABLE'
+  );
+}
+
+/** Convert only supported, valid URL values into directory state. */
+function stateFromSearchParams(searchParams: URLSearchParams): DirectoryState {
+  const parsedPage = Number.parseInt(searchParams.get('page') ?? '', 10);
+  const status = searchParams.get('status');
+  const sort = searchParams.get('sort');
+  const skills = searchParams
+    .getAll('skills')
+    .flatMap(value => value.split(','))
+    .map(value => value.trim())
+    .filter(Boolean);
+
+  return {
+    search: searchParams.get('search') ?? '',
+    skills: [...new Set(skills)],
+    country: searchParams.get('country') ?? '',
+    status: isBuilderStatus(status) ? status : '',
+    sort: isBuilderSort(sort) ? sort : DEFAULT_SORT,
+    page: Number.isSafeInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1,
+  };
+}
+
+function stateToSearchParams(state: DirectoryState): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  if (state.search) searchParams.set('search', state.search);
+  if (state.skills.length) searchParams.set('skills', state.skills.join(','));
+  if (state.country) searchParams.set('country', state.country);
+  if (state.status) searchParams.set('status', state.status);
+  if (state.sort !== DEFAULT_SORT) searchParams.set('sort', state.sort);
+  if (state.page !== 1) searchParams.set('page', String(state.page));
+  return searchParams;
+}
+
+function toBuilderCard(builder: {
+  id: string;
+  name: string | null;
+  username: string | null;
+  image: string | null;
+  role: string | null;
+  location: string | null;
+  country: string | null;
+  skills: string[];
+}) {
+  const username = builder.username ?? builder.id;
+  return {
+    id: builder.id,
+    displayName: builder.name ?? username,
+    username,
+    avatarSrc: builder.image ?? undefined,
+    role: builder.role ?? undefined,
+    location: builder.location ?? builder.country ?? undefined,
+    skills: builder.skills.slice(0, 4),
+    detailUrl: `/builders/${username}`,
+  };
+}
+
+/** Public builders directory with URL-backed, shareable search and filters. */
+export function BuildersView() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const serializedSearchParams = searchParams.toString();
+  const urlState = useMemo(
+    () => stateFromSearchParams(new URLSearchParams(serializedSearchParams)),
+    [serializedSearchParams]
+  );
+  const [state, setState] = useState<DirectoryState>(urlState);
+  const [searchInput, setSearchInput] = useState(urlState.search);
+  const { data: facets } = useBuilderFilters();
+
+  // A browser back/forward navigation changes Next's search params. Mirror that
+  // external state into the controls without adding another history entry.
+  useEffect(() => {
+    setState(urlState);
+    setSearchInput(urlState.search);
+  }, [urlState]);
+
+  const navigate = useCallback(
+    (next: DirectoryState, replace = false) => {
+      setState(next);
+      const query = stateToSearchParams(next).toString();
+      const href = query ? `${pathname}?${query}` : pathname;
+      if (replace) router.replace(href, { scroll: false });
+      else router.push(href, { scroll: false });
+    },
+    [pathname, router]
+  );
+
+  // Search is deliberately debounced. Replacing here means a sentence typed
+  // into the search box contributes no per-keystroke browser history entries.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchInput !== state.search) {
+        navigate({ ...state, search: searchInput, page: 1 }, true);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [navigate, searchInput, state]);
+
+  const params = useMemo(
+    () => ({
+      page: state.page,
+      limit: PAGE_SIZE,
+      search: state.search || undefined,
+      skills: state.skills.length ? state.skills : undefined,
+      country: state.country || undefined,
+      status: state.status || undefined,
+      sort: state.sort,
+    }),
+    [state]
+  );
+  const { data, isPending, isError } = useBuilders(params);
+
+  const update = (patch: Partial<DirectoryState>) =>
+    navigate({ ...state, ...patch, page: patch.page ?? 1 });
+  const toggleSkill = (skill: string) =>
+    update({
+      skills: state.skills.includes(skill)
+        ? state.skills.filter(item => item !== skill)
+        : [...state.skills, skill],
+    });
+
+  return (
+    <Section className='py-10 lg:py-12' innerClassName='flex flex-col gap-6'>
+      <div>
+        <h1 className='text-3xl font-semibold text-foreground'>Builders</h1>
+        <p className='mt-2 text-muted-foreground'>
+          Discover people building across the Boundless ecosystem.
+        </p>
+      </div>
+
+      <div className='flex flex-wrap gap-3'>
+        <label className='flex min-w-56 flex-1 items-center gap-2 rounded-full border border-border px-4 py-2'>
+          <Search className='size-4 text-muted-foreground' aria-hidden />
+          <input
+            className='w-full bg-transparent text-sm outline-none'
+            value={searchInput}
+            onChange={event => setSearchInput(event.target.value)}
+            placeholder='Search builders'
+          />
+        </label>
+        <select
+          aria-label='Country'
+          value={state.country}
+          onChange={event => update({ country: event.target.value })}
+          className='rounded-full border border-border bg-transparent px-4 py-2 text-sm'
+        >
+          <option value=''>All countries</option>
+          {facets?.countries.map(country => (
+            <option key={country.value} value={country.value}>
+              {country.value} ({country.count})
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label='Availability status'
+          value={state.status}
+          onChange={event =>
+            update({ status: event.target.value as BuilderStatus | '' })
+          }
+          className='rounded-full border border-border bg-transparent px-4 py-2 text-sm'
+        >
+          <option value=''>All statuses</option>
+          {facets?.statuses.map(status => (
+            <option key={status} value={status}>
+              {status.replaceAll('_', ' ')}
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label='Sort builders'
+          value={state.sort}
+          onChange={event => update({ sort: event.target.value as BuilderSort })}
+          className='rounded-full border border-border bg-transparent px-4 py-2 text-sm'
+        >
+          <option value='newest'>Newest</option>
+          <option value='oldest'>Oldest</option>
+          <option value='name_asc'>Name: A–Z</option>
+          <option value='name_desc'>Name: Z–A</option>
+        </select>
+      </div>
+
+      {facets?.skills.length ? (
+        <div className='flex flex-wrap gap-2'>
+          {facets.skills.map(skill => (
+            <button
+              key={skill.value}
+              type='button'
+              onClick={() => toggleSkill(skill.value)}
+              className='rounded-full border border-border px-3 py-1 text-sm'
+              aria-pressed={state.skills.includes(skill.value)}
+            >
+              {skill.value} ({skill.count})
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {isPending ? (
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
+          {Array.from({ length: PAGE_SIZE }, (_, index) => (
+            <BuilderCardSkeleton key={index} />
+          ))}
+        </div>
+      ) : null}
+      {isError || !data ? (
+        !isPending ? (
+          <p className='py-12 text-center text-muted-foreground'>
+            Builders could not be loaded right now.
+          </p>
+        ) : null
+      ) : data.data.length === 0 ? (
+        <p className='py-12 text-center text-muted-foreground'>
+          No builders match these filters.
+        </p>
+      ) : (
+        <div className='flex flex-col gap-8'>
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3'>
+            {data.data.map(builder => (
+              <BuilderCard key={builder.id} builder={toBuilderCard(builder)} />
+            ))}
+          </div>
+          <Pagination
+            page={state.page}
+            pageSize={PAGE_SIZE}
+            totalItems={data.pagination.total}
+            onPageChange={page => update({ page })}
+            className='justify-between'
+          />
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/components/builders/use-builders.ts
+++ b/components/builders/use-builders.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { apiFetch } from '@/lib/api/client';
+import type { Paginated, Schemas } from '@/lib/api/types';
+
+type BuilderListItem = Schemas['BuilderListItemDto'];
+export type BuilderStatus = NonNullable<BuilderListItem['status']>;
+export type BuilderSort = 'name_asc' | 'name_desc' | 'newest' | 'oldest';
+
+export interface BuildersQueryParams {
+  page: number;
+  limit: number;
+  search?: string;
+  skills?: string[];
+  country?: string;
+  status?: BuilderStatus;
+  sort?: BuilderSort;
+}
+
+export interface BuilderFiltersResponse {
+  skills: { value: string; count: number }[];
+  countries: { value: string; count: number }[];
+  statuses: BuilderStatus[];
+}
+
+function toQueryString(params: BuildersQueryParams): string {
+  const query = new URLSearchParams({
+    page: String(params.page),
+    limit: String(params.limit),
+  });
+
+  if (params.search) query.set('search', params.search);
+  if (params.skills?.length) query.set('skills', params.skills.join(','));
+  if (params.country) query.set('country', params.country);
+  if (params.status) query.set('status', params.status);
+  if (params.sort) query.set('sort', params.sort);
+
+  return `?${query.toString()}`;
+}
+
+export function useBuilders(params: BuildersQueryParams) {
+  return useQuery({
+    queryKey: ['builders', params],
+    queryFn: () =>
+      apiFetch<Paginated<Schemas['BuilderListItemDto']>>(
+        `/users/directory${toQueryString(params)}`
+      ),
+  });
+}
+
+export function useBuilderFilters() {
+  return useQuery({
+    queryKey: ['builders', 'filters'],
+    queryFn: () => apiFetch<BuilderFiltersResponse>('/users/directory/filters'),
+  });
+}


### PR DESCRIPTION
close #369 

Motivation
Provide a public, shareable builders directory whose filter, search, sort, and pagination state can be copied as a URL and navigated via browser history.
Persist directory controls in the query string so back/forward navigation and bookmarking produce the same filtered view.
Avoid creating a history entry per keystroke by debouncing search input and using replace navigation for search updates.

Description
Add a new builders route at app/builders/page.tsx that mounts a client BuildersView inside a Suspense boundary.
Add components/builders/use-builders.ts with useBuilders and useBuilderFilters hooks that call the backend endpoints (/users/directory and /users/directory/filters) and serialize query params.
Implement components/builders/builders-view.tsx, a URL-backed client directory that reads initial state from useSearchParams(), validates params, omits defaults when serializing, debounces search and uses router.replace for search and router.push for filter/sort/page changes, renders filter controls, skill chips, and paginated results.
Map API builder items to the existing BuilderCard view model and show skeletons / error / empty states; page size is 12 and default sort is newest.

Testing
Ran git diff --check with no reported problems.
Ran npm run lint (ESLint) which completed successfully.
Ran npx tsc --noEmit which passed type checking.
Ran npm run build which failed in this environment because Next.js could not fetch Google Fonts from fonts.googleapis.com, causing the production build to abort (network-restricted environment), not a code compile error.
