### PR TITLE
feat(discover): implement exclusive radio selection for filters

### DIFF
--- a/components/discover/filter-rail.tsx
+++ b/components/discover/filter-rail.tsx
@@ -16,6 +16,7 @@ import {
   Tag02Icon,
 } from '@/components/icons';
 import { Checkbox } from '@/components/ui/checkbox';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Skeleton } from '@/components/ui/skeleton';
 import { transitions } from '@/lib/motion';
 import { cn } from '@/lib/utils';
@@ -23,7 +24,7 @@ import { cn } from '@/lib/utils';
 import type { FacetCount } from './use-projects';
 import { useProjectFilters } from './use-projects';
 
-export type CheckboxGroup =
+export type FilterGroup =
   | 'category'
   | 'tags'
   | 'publicStatus'
@@ -136,6 +137,42 @@ function CheckRow({
   );
 }
 
+function RadioRow({
+  id,
+  value,
+  label,
+  checked,
+  onClear,
+}: {
+  id: string;
+  value: string;
+  label: string;
+  checked: boolean;
+  onClear: () => void;
+}) {
+  return (
+    <label htmlFor={id} className='flex cursor-pointer items-center gap-2'>
+      <RadioGroupItem
+        id={id}
+        value={value}
+        onPointerDown={event => {
+          // Clicking the selected radio clears the filter.
+          if (checked) {
+            event.preventDefault();
+            onClear();
+          }
+        }}
+      />
+      <span className='text-sm text-muted-foreground'>{label}</span>
+    </label>
+  );
+}
+
+/** Keep at most one selected value. Clicking the current value clears it. */
+function nextExclusiveValue(current: string[], item: string): string[] {
+  return current[0] === item ? [] : [item];
+}
+
 /**
  * Discovery filter controls, used in the desktop sidebar and the mobile sheet.
  * Controlled: the parent owns `value` so it can show a Reset affordance and run
@@ -154,33 +191,50 @@ export function FilterRail({
 }) {
   const { data, isPending, isError } = useProjectFilters();
 
-  const toggle = (group: CheckboxGroup, item: string) => {
-    const current = value[group];
+  const selectExclusive = (group: FilterGroup, item: string) => {
+    onChange({ ...value, [group]: nextExclusiveValue(value[group], item) });
+  };
+
+  const toggleTag = (item: string) => {
+    const current = value.tags;
     const next = current.includes(item)
       ? current.filter(entry => entry !== item)
       : [...current, item];
-    onChange({ ...value, [group]: next });
+    onChange({ ...value, tags: next });
   };
 
-  const renderFacetRows = (group: CheckboxGroup, items: FacetCount[]) =>
+  const renderExclusiveRows = (
+    group: FilterGroup,
+    items: { value: string; label: string }[],
+    title: string
+  ) => (
+    <RadioGroup
+      value={value[group][0] ?? ''}
+      onValueChange={item => selectExclusive(group, item)}
+      name={`${idPrefix}-${group}`}
+      aria-label={title}
+    >
+      {items.map(item => (
+        <RadioRow
+          key={item.value}
+          id={`${idPrefix}-${group}-${item.value}`}
+          value={item.value}
+          label={item.label}
+          checked={value[group][0] === item.value}
+          onClear={() => selectExclusive(group, item.value)}
+        />
+      ))}
+    </RadioGroup>
+  );
+
+  const renderTagRows = (items: FacetCount[]) =>
     items.map(item => (
       <CheckRow
         key={item.value}
-        id={`${idPrefix}-${group}-${item.value}`}
+        id={`${idPrefix}-tags-${item.value}`}
         label={`${item.value} (${item.count})`}
-        checked={value[group].includes(item.value)}
-        onToggle={() => toggle(group, item.value)}
-      />
-    ));
-
-  const renderEnumRows = (group: CheckboxGroup, items: string[]) =>
-    items.map(item => (
-      <CheckRow
-        key={item}
-        id={`${idPrefix}-${group}-${item}`}
-        label={formatLabel(item)}
-        checked={value[group].includes(item)}
-        onToggle={() => toggle(group, item)}
+        checked={value.tags.includes(item.value)}
+        onToggle={() => toggleTag(item.value)}
       />
     ));
 
@@ -205,19 +259,40 @@ export function FilterRail({
   return (
     <div className={cn('flex flex-col', className)}>
       <FilterSection icon={Activity01Icon} title='Status'>
-        {renderEnumRows('publicStatus', data.publicStatuses)}
+        {renderExclusiveRows(
+          'publicStatus',
+          data.publicStatuses.map(item => ({
+            value: item,
+            label: formatLabel(item),
+          })),
+          'Status'
+        )}
       </FilterSection>
 
       <FilterSection icon={CompassIcon} title='Origin'>
-        {renderEnumRows('originType', data.originTypes)}
+        {renderExclusiveRows(
+          'originType',
+          data.originTypes.map(item => ({
+            value: item,
+            label: formatLabel(item),
+          })),
+          'Origin'
+        )}
       </FilterSection>
 
       <FilterSection icon={HashtagIcon} title='Category'>
-        {renderFacetRows('category', data.categories)}
+        {renderExclusiveRows(
+          'category',
+          data.categories.map(item => ({
+            value: item.value,
+            label: `${item.value} (${item.count})`,
+          })),
+          'Category'
+        )}
       </FilterSection>
 
       <FilterSection icon={Tag02Icon} title='Tags' defaultOpen={false}>
-        {renderFacetRows('tags', data.tags)}
+        {renderTagRows(data.tags)}
       </FilterSection>
     </div>
   );

--- a/components/discover/projects-view.tsx
+++ b/components/discover/projects-view.tsx
@@ -59,8 +59,8 @@ export function ProjectsView() {
       page,
       limit: PAGE_SIZE,
       search: search || undefined,
-      // `GET /projects` takes a single value for these three, so a multi-select
-      // in the rail sends its first entry. Only `tags` is repeatable.
+      // Exclusive radios in the rail; `[0]` is the selected value or none.
+      // Only `tags` is repeatable.
       category: filters.category[0],
       publicStatus: filters.publicStatus[0],
       originType: filters.originType[0],

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { RadioGroup as RadioGroupPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot='radio-group'
+      className={cn('flex flex-col gap-3', className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot='radio-group-item'
+      className={cn(
+        'peer grid size-4 shrink-0 place-items-center rounded-full border border-[#2e3a38] bg-transparent transition-colors outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary-500',
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className='grid place-items-center'>
+        <span className='size-2 rounded-full bg-primary-500' />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };


### PR DESCRIPTION
## Summary
- Status, Origin, and Category on the projects filter rail (and mobile sheet) are radios, matching the single value the API accepts
- Tags stay multi-select checkboxes

## Why
The rail allowed multiple ticks, but only the first value was sent, so the UI could disagree with the query. Closes that mismatch without a backend change.

## How it was tested
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Browser: select a second Status/Origin option (only one remains); clear by clicking the selected radio; repeat in the mobile sheet

Closes #373

## Test plan
- [x] On `/projects` (desktop), tick Status Live, then Beta. Only Beta stays selected and results follow Beta
- [x] Untick Beta by clicking it again. The status filter clears; it does not silently jump to another value
- [x] Repeat for Origin and Category
- [x] Tags still allow more than one checkbox
- [x] On a mobile viewport, open the filter sheet and confirm the same radio behavior